### PR TITLE
Use nodeJS hmcts base image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8
+FROM hmcts.azurecr.io/hmcts/base/node/stretch-slim-lts-8
 
 RUN apt-get update \
     && apt-get install -yyq ca-certificates \


### PR DESCRIPTION
Hi, not sure this PR is worth it, but as we now have [base nodeJS images in ACR](https://github.com/hmcts/cnp-node-base), which are aimed at being updated with security patches only, you may be interested in using it.

I assume this project is not intended at running in production, but these base images expose a `hmcts` user you might use in prod apps.

Thx.