### PR TITLE
RIA-1023: Run CCD UI e2e tests using Jenkins Nightly pipeline

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -38,17 +38,6 @@ withNightlyPipeline("nodejs", product, component) {
     loadVaultSecrets(secrets)
 
     env.TEST_E2E_URL_WEB = params.URL_TO_TEST
-
-    before('functionalTest:aat') {
-        sh 'echo BEFORE functionalTest:aat'
-//        sh 'yarn e2e'
-    }
-
-    before('fullFunctionalTest') {
-        sh 'echo BEFORE fullFunctionalTest'
-//        sh 'yarn e2e'
-    }
-
     enableFullFunctionalTest()
 
 //    enableSlackNotifications('#immigrationandasylum')  // can be turned back on once the overnight functionality is working fully

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -3,13 +3,7 @@
 properties([
         pipelineTriggers([cron('00 22 * * *')]),
         parameters([
-                string(name: 'URL_TO_TEST', defaultValue: 'https://www-ccd.aat.platform.hmcts.net', description: 'The URL you want to run these tests against'),
-                string(name: 'CCD_USERNAME', defaultValue: '', description: 'The CCD Username you want to run these tests with'),
-                string(name: 'CCD_PASSWORD', defaultValue: '', description: 'The CCD Password you want to run these tests with'),
-                string(name: 'A_USERNAME', defaultValue: '', description: 'The A Username you want to run these tests with'),
-                string(name: 'A_PASSWORD', defaultValue: '', description: 'The A Password you want to run these tests with'),
-                string(name: 'B_USERNAME', defaultValue: '', description: 'The B Username you want to run these tests with'),
-                string(name: 'B_PASSWORD', defaultValue: '', description: 'The B Password you want to run these tests with')
+                string(name: 'URL_TO_TEST', defaultValue: 'https://www-ccd.aat.platform.hmcts.net', description: 'The URL you want to run these tests against')
         ])
 ])
 
@@ -18,15 +12,21 @@ properties([
 def product = "ia"
 def component = "ccd-e2e-tests"
 
-withNightlyPipeline("nodejs", product, component) {
-    env.TEST_E2E_URL_WEB = params.URL_TO_TEST
-    env.TEST_CASEOFFICER_USERNAME = params.CCD_USERNAME
-    env.TEST_CASEOFFICER_PASSWORD = params.CCD_PASSWORD
-    env.TEST_LAW_FIRM_A_USERNAME = params.A_USERNAME
-    env.TEST_LAW_FIRM_A_PASSWORD = params.A_PASSWORD
-    env.TEST_LAW_FIRM_B_USERNAME = params.B_USERNAME
-    env.TEST_LAW_FIRM_B_PASSWORD = params.B_PASSWORD
+List<LinkedHashMap<String, Object>> secrets = [
 
+        secret('test-caseofficer-username', 'TEST_CASEOFFICER_USERNAME'),
+        secret('test-caseofficer-password', 'TEST_CASEOFFICER_PASSWORD'),
+        secret('test-law-firm-a-username', 'TEST_LAW_FIRM_A_USERNAME'),
+        secret('test-law-firm-a-password', 'TEST_LAW_FIRM_A_PASSWORD'),
+        secret('test-law-firm-b-username', 'TEST_LAW_FIRM_B_USERNAME'),
+        secret('test-law-firm-b-password', 'TEST_LAW_FIRM_B_PASSWORD')
+]
+
+withNightlyPipeline("nodejs", product, component) {
+    setVaultName('ia')
+    loadVaultSecrets(secrets)
+
+    env.TEST_E2E_URL_WEB = params.URL_TO_TEST
     enableFullFunctionalTest()
 
 //    enableSlackNotifications('#immigrationandasylum')  // can be turned back on once the overnight functionality is working fully

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -19,7 +19,9 @@ List<LinkedHashMap<String, Object>> secrets = [
         secret('test-law-firm-a-username', 'TEST_LAW_FIRM_A_USERNAME'),
         secret('test-law-firm-a-password', 'TEST_LAW_FIRM_A_PASSWORD'),
         secret('test-law-firm-b-username', 'TEST_LAW_FIRM_B_USERNAME'),
-        secret('test-law-firm-b-password', 'TEST_LAW_FIRM_B_PASSWORD')
+        secret('test-law-firm-b-password', 'TEST_LAW_FIRM_B_PASSWORD'),
+        secret('test-law-firm-c-username', 'TEST_LAW_FIRM_C_USERNAME'),
+        secret('test-law-firm-c-password', 'TEST_LAW_FIRM_C_PASSWORD')
 ]
 
 static LinkedHashMap<String, Object> secret(String secretName, String envVar) {

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -4,7 +4,7 @@ properties([
         pipelineTriggers([cron('00 22 * * *')]),
         parameters([
                 string(name: 'URL_TO_TEST', defaultValue: 'https://www-ccd.aat.platform.hmcts.net', description: 'The URL you want to run these tests against'),
-                string(name: 'NUM_TESTS_IN_PARALLEL', defaultValue: '3', description: 'The number of tests to run in parallel')
+                string(name: 'NUM_TESTS_IN_PARALLEL', defaultValue: '5', description: 'The number of tests to run in parallel')
         ])
 ])
 

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -5,7 +5,11 @@ properties([
         parameters([
                 string(name: 'URL_TO_TEST', defaultValue: 'https://www-ccd.nonprod.platform.hmcts.net', description: 'The URL you want to run these tests against'),
                 string(name: 'CCD_USERNAME', defaultValue: '', description: 'The CCD Username you want to run these tests with'),
-                string(name: 'CCD_PASSWORD', defaultValue: '', description: 'The CCD Password you want to run these tests with')
+                string(name: 'CCD_PASSWORD', defaultValue: '', description: 'The CCD Password you want to run these tests with'),
+                string(name: 'A_USERNAME', defaultValue: '', description: 'The A Username you want to run these tests with'),
+                string(name: 'A_PASSWORD', defaultValue: '', description: 'The A Password you want to run these tests with'),
+                string(name: 'B_USERNAME', defaultValue: '', description: 'The B Username you want to run these tests with'),
+                string(name: 'B_PASSWORD', defaultValue: '', description: 'The B Password you want to run these tests with')
         ])
 ])
 
@@ -18,6 +22,10 @@ withNightlyPipeline("nodejs", product, component) {
     env.TEST_E2E_URL_WEB = params.URL_TO_TEST
     env.TEST_CASEOFFICER_USERNAME = params.CCD_USERNAME
     env.TEST_CASEOFFICER_PASSWORD = params.CCD_PASSWORD
+    env.TEST_LAW_FIRM_A_USERNAME = params.A_USERNAME
+    env.TEST_LAW_FIRM_A_PASSWORD = params.A_PASSWORD
+    env.TEST_LAW_FIRM_B_USERNAME = params.B_USERNAME
+    env.TEST_LAW_FIRM_B_PASSWORD = params.B_PASSWORD
 
     enableFullFunctionalTest()
 

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -3,7 +3,7 @@
 properties([
         pipelineTriggers([cron('00 22 * * *')]),
         parameters([
-                string(name: 'URL_TO_TEST', defaultValue: 'https://www-ccd.nonprod.platform.hmcts.net', description: 'The URL you want to run these tests against'),
+                string(name: 'URL_TO_TEST', defaultValue: 'https://www-ccd.aat.platform.hmcts.net', description: 'The URL you want to run these tests against'),
                 string(name: 'CCD_USERNAME', defaultValue: '', description: 'The CCD Username you want to run these tests with'),
                 string(name: 'CCD_PASSWORD', defaultValue: '', description: 'The CCD Password you want to run these tests with'),
                 string(name: 'A_USERNAME', defaultValue: '', description: 'The A Username you want to run these tests with'),

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -22,6 +22,15 @@ List<LinkedHashMap<String, Object>> secrets = [
         secret('test-law-firm-b-password', 'TEST_LAW_FIRM_B_PASSWORD')
 ]
 
+static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
+    [$class     : 'AzureKeyVaultSecret',
+     secretType : 'Secret',
+     name       : secretName,
+     version    : '',
+     envVariable: envVar
+    ]
+}
+
 withNightlyPipeline("nodejs", product, component) {
     setVaultName('ia')
     loadVaultSecrets(secrets)

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -1,7 +1,7 @@
 #!groovy
 
 properties([
-        pipelineTriggers([cron('00 22 * * *')]),
+        pipelineTriggers([cron('00 23 * * *')]),
         parameters([
                 string(name: 'URL_TO_TEST', defaultValue: 'https://www-ccd.aat.platform.hmcts.net', description: 'The URL you want to run these tests against'),
                 string(name: 'NUM_TESTS_IN_PARALLEL', defaultValue: '5', description: 'The number of tests to run in parallel')

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -39,7 +39,7 @@ withNightlyPipeline("nodejs", product, component) {
     loadVaultSecrets(secrets)
 
     env.TEST_E2E_URL_WEB = params.URL_TO_TEST
-    env.TEST_E2E_URL_WEB = params.NUM_TESTS_IN_PARALLEL
+    env.NUM_TESTS_IN_PARALLEL = params.NUM_TESTS_IN_PARALLEL
     enableFullFunctionalTest()
 
 //    enableSlackNotifications('#immigrationandasylum')  // can be turned back on once the overnight functionality is working fully

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -39,7 +39,7 @@ withNightlyPipeline("nodejs", product, component) {
     loadVaultSecrets(secrets)
 
     env.TEST_E2E_URL_WEB = params.URL_TO_TEST
-    env.NUM_TESTS_IN_PARALLEL = params.NUM_TESTS_IN_PARALLEL
+    env.TEST_E2E_NUM_BROWSERS = params.NUM_TESTS_IN_PARALLEL
     enableFullFunctionalTest()
 
 //    enableSlackNotifications('#immigrationandasylum')  // can be turned back on once the overnight functionality is working fully

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -3,7 +3,8 @@
 properties([
         pipelineTriggers([cron('00 22 * * *')]),
         parameters([
-                string(name: 'URL_TO_TEST', defaultValue: 'https://www-ccd.aat.platform.hmcts.net', description: 'The URL you want to run these tests against')
+                string(name: 'URL_TO_TEST', defaultValue: 'https://www-ccd.aat.platform.hmcts.net', description: 'The URL you want to run these tests against'),
+                string(name: 'NUM_TESTS_IN_PARALLEL', defaultValue: '3', description: 'The number of tests to run in parallel')
         ])
 ])
 
@@ -38,6 +39,7 @@ withNightlyPipeline("nodejs", product, component) {
     loadVaultSecrets(secrets)
 
     env.TEST_E2E_URL_WEB = params.URL_TO_TEST
+    env.TEST_E2E_URL_WEB = params.NUM_TESTS_IN_PARALLEL
     enableFullFunctionalTest()
 
 //    enableSlackNotifications('#immigrationandasylum')  // can be turned back on once the overnight functionality is working fully

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -36,6 +36,17 @@ withNightlyPipeline("nodejs", product, component) {
     loadVaultSecrets(secrets)
 
     env.TEST_E2E_URL_WEB = params.URL_TO_TEST
+
+    before('functionalTest:aat') {
+        sh 'echo BEFORE functionalTest:aat'
+//        sh 'yarn e2e'
+    }
+
+    before('fullFunctionalTest') {
+        sh 'echo BEFORE fullFunctionalTest'
+//        sh 'yarn e2e'
+    }
+
     enableFullFunctionalTest()
 
 //    enableSlackNotifications('#immigrationandasylum')  // can be turned back on once the overnight functionality is working fully

--- a/e2e/cucumber.conf.js
+++ b/e2e/cucumber.conf.js
@@ -1,2 +1,2 @@
 const { setDefaultTimeout } = require('cucumber');
-setDefaultTimeout(60 * 1000);
+setDefaultTimeout(120 * 1000);

--- a/e2e/cucumber.conf.js
+++ b/e2e/cucumber.conf.js
@@ -1,2 +1,2 @@
 const { setDefaultTimeout } = require('cucumber');
-setDefaultTimeout(120 * 1000);
+setDefaultTimeout(180 * 1000);

--- a/e2e/enums/wait.ts
+++ b/e2e/enums/wait.ts
@@ -1,8 +1,8 @@
 const iaConfig = require('../ia.conf');
 
 export enum Wait {
-    minimal = iaConfig.RunningOnAAT ? 3000 : 100,
-    short = iaConfig.RunningOnAAT ? 5000 : 1000,
+    minimal = iaConfig.RunningOnAAT ? 5000 : 100,
+    short = iaConfig.RunningOnAAT ? 10000 : 1000,
     normal = iaConfig.RunningOnAAT ? 30000 : 10000,
     long = iaConfig.RunningOnAAT ? 120000 : 60000
 }

--- a/e2e/enums/wait.ts
+++ b/e2e/enums/wait.ts
@@ -1,6 +1,8 @@
+const iaConfig = require('../ia.conf');
+
 export enum Wait {
-    minimal = 100,
-    short = 1000,
-    normal = 10000,
-    long = 60000
+    minimal = iaConfig.RunningOnAAT ? 500 : 100,
+    short = iaConfig.RunningOnAAT ? 5000 : 1000,
+    normal = iaConfig.RunningOnAAT ? 30000 : 10000,
+    long = iaConfig.RunningOnAAT ? 120000 : 60000
 }

--- a/e2e/enums/wait.ts
+++ b/e2e/enums/wait.ts
@@ -1,7 +1,7 @@
 const iaConfig = require('../ia.conf');
 
 export enum Wait {
-    minimal = iaConfig.RunningOnAAT ? 500 : 100,
+    minimal = iaConfig.RunningOnAAT ? 3000 : 100,
     short = iaConfig.RunningOnAAT ? 5000 : 1000,
     normal = iaConfig.RunningOnAAT ? 30000 : 10000,
     long = iaConfig.RunningOnAAT ? 120000 : 60000

--- a/e2e/enums/wait.ts
+++ b/e2e/enums/wait.ts
@@ -3,6 +3,6 @@ const iaConfig = require('../ia.conf');
 export enum Wait {
     minimal = iaConfig.RunningOnAAT ? 3000 : 100,
     short = iaConfig.RunningOnAAT ? 10000 : 1000,
-    normal = iaConfig.RunningOnAAT ? 30000 : 10000,
+    normal = iaConfig.RunningOnAAT ? 40000 : 10000,
     long = iaConfig.RunningOnAAT ? 120000 : 60000
 }

--- a/e2e/enums/wait.ts
+++ b/e2e/enums/wait.ts
@@ -1,7 +1,7 @@
 const iaConfig = require('../ia.conf');
 
 export enum Wait {
-    minimal = iaConfig.RunningOnAAT ? 5000 : 100,
+    minimal = iaConfig.RunningOnAAT ? 3000 : 100,
     short = iaConfig.RunningOnAAT ? 10000 : 1000,
     normal = iaConfig.RunningOnAAT ? 30000 : 10000,
     long = iaConfig.RunningOnAAT ? 120000 : 60000

--- a/e2e/features.conf.js
+++ b/e2e/features.conf.js
@@ -9,6 +9,8 @@ exports.config = {
 
   baseUrl: iaConfig.CcdWebUrl,
   specs: ['./features/*.feature'],
+  allScriptsTimeout: 120000,
+  getPageTimeout: 120000,
 
   capabilities: {
     browserName: 'chrome',
@@ -55,7 +57,7 @@ exports.config = {
     keepAlive: false,
     tags: false,
     profile: false,
-    'fail-fast': true,
+    'fail-fast': !iaConfig.RunningOnAAT,
     'no-source': true
   },
 

--- a/e2e/features/add-appeal-response.feature
+++ b/e2e/features/add-appeal-response.feature
@@ -40,7 +40,6 @@ Feature: Add respondent response
     When I click the `Close and Return to case details` button
     And I click the `Documents` tab
     Then I should see the `Documents` page
-    And I should see the `Respondent documents` field
     And within the `Respondent documents` collection's first item, I should see `AppealResponse.pdf` in the `Document` field
     And within the `Respondent documents` collection's first item, I should see `This is the appeal response` in the `Description` field
     And within the `Respondent documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
@@ -50,7 +49,6 @@ Feature: Add respondent response
 
     When I click the `Directions` tab
     Then I should see the `Directions` page
-    And I should see the `Directions` field
     And within the `Directions` collection's first item, I should see `The respondent has replied to your appeal argument and evidence. You must now review their response.` in the `Explanation` field
     And within the `Directions` collection's first item, I should see `You have 5 days to review the response.` in the `Explanation` field
     And within the `Directions` collection's first item, I should see `Legal representative` for the `Parties` field

--- a/e2e/features/add-appeal-response.feature
+++ b/e2e/features/add-appeal-response.feature
@@ -39,7 +39,8 @@ Feature: Add respondent response
 
     When I click the `Close and Return to case details` button
     And I click the `Documents` tab
-    Then I should see the `Respondent documents` field
+    Then I should see the `Documents` page
+    And I should see the `Respondent documents` field
     And within the `Respondent documents` collection's first item, I should see `AppealResponse.pdf` in the `Document` field
     And within the `Respondent documents` collection's first item, I should see `This is the appeal response` in the `Description` field
     And within the `Respondent documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
@@ -48,7 +49,8 @@ Feature: Add respondent response
     And within the `Respondent documents` collection's second item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
 
     When I click the `Directions` tab
-    Then I should see the `Directions` field
+    Then I should see the `Directions` page
+    And I should see the `Directions` field
     And within the `Directions` collection's first item, I should see `The respondent has replied to your appeal argument and evidence. You must now review their response.` in the `Explanation` field
     And within the `Directions` collection's first item, I should see `You have 5 days to review the response.` in the `Explanation` field
     And within the `Directions` collection's first item, I should see `Legal representative` for the `Parties` field

--- a/e2e/features/appeal-submission-pdf.feature
+++ b/e2e/features/appeal-submission-pdf.feature
@@ -1,6 +1,6 @@
 Feature: Appeal submission PDF
 
-  @overview-tab @RIA-769
+  @overview-tab @RIA-769 @toggled-off
   Scenario: Appeal submission PDF is in documents tab
 
     Given I am signed in as a `Legal Rep`

--- a/e2e/features/appeal-submission-pdf.feature
+++ b/e2e/features/appeal-submission-pdf.feature
@@ -9,6 +9,7 @@ Feature: Appeal submission PDF
     And I submit my appeal
 
     When I click the `Documents` tab
-    Then I should see the `Legal representative documents` field
+    Then I should see the `Documents` page
+    And I should see the `Legal representative documents` field
     And within the `Legal representative documents` collection's first item, I should see `-Gonzlez-appeal-form.PDF` in the `Document` field
     And within the `Legal representative documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field

--- a/e2e/features/appeal-tab.feature
+++ b/e2e/features/appeal-tab.feature
@@ -8,12 +8,14 @@ Feature: Appeal tab
     And I save my initial appeal
     And I submit my appeal
     And I click the `Appeal` tab
+    And I should see the `Appeal` page
     And I should see `Removing the appellant from the UK would breach the UK's obligation under the Refugee Convention` in the `Grounds of appeal` field
     And I should see `The refusal of a protection claim` in the `Type of appeal` field
 
     When I switch to be a `Case Officer`
     And I click the `Appeal` tab
-    Then I should see `Removing the appellant from the UK would breach the UK's obligation under the Refugee Convention` in the `Grounds of appeal` field
+    Then I should see the `Appeal` page
+    And I should see `Removing the appellant from the UK would breach the UK's obligation under the Refugee Convention` in the `Grounds of appeal` field
     And I should see `The refusal of a protection claim` in the `Type of appeal` field
 
     When I request respondent evidence
@@ -22,7 +24,8 @@ Feature: Appeal tab
     And I build my case
     And I submit my case
     And I click the `Appeal` tab
-    Then I should see `CaseArgument.pdf` in the `Appeal skeleton argument` field
+    Then I should see the `Appeal` page
+    And I should see `CaseArgument.pdf` in the `Appeal skeleton argument` field
     And I should see `This is the case argument` in the `Description` field
     And within the `Evidence` collection's first item, I should see `CaseArgumentEvidence.pdf` in the `Document` field
     And within the `Evidence` collection's first item, I should see `The is the case argument evidence` in the `Describe the document` field
@@ -31,7 +34,8 @@ Feature: Appeal tab
 
     When I switch to be a `Case Officer`
     And I click the `Appeal` tab
-    Then I should see `CaseArgument.pdf` in the `Appeal skeleton argument` field
+    Then I should see the `Appeal` page
+    And I should see `CaseArgument.pdf` in the `Appeal skeleton argument` field
     And I should see `This is the case argument` in the `Description` field
     And within the `Evidence` collection's first item, I should see `CaseArgumentEvidence.pdf` in the `Document` field
     And within the `Evidence` collection's first item, I should see `The is the case argument evidence` in the `Describe the document` field
@@ -41,7 +45,8 @@ Feature: Appeal tab
     When I request respondent review
     And I add the appeal response
     And I click the `Appeal` tab
-    Then I should see `AppealResponse.pdf` in the `Response document` field
+    Then I should see the `Appeal` page
+    And I should see `AppealResponse.pdf` in the `Response document` field
     And I should see `This is the appeal response` in the first `Description` field
     And within the first `Evidence` collection's first item, I should see `AppealResponseEvidence.pdf` in the `Document` field
     And within the first `Evidence` collection's first item, I should see `This is the appeal response evidence` in the `Describe the document` field
@@ -53,7 +58,8 @@ Feature: Appeal tab
 
     When I switch to be a `Legal Rep`
     And I click the `Appeal` tab
-    Then I should see `AppealResponse.pdf` in the `Response document` field
+    Then I should see the `Appeal` page
+    And I should see `AppealResponse.pdf` in the `Response document` field
     And I should see `This is the appeal response` in the first `Description` field
     And within the first `Evidence` collection's first item, I should see `AppealResponseEvidence.pdf` in the `Document` field
     And within the first `Evidence` collection's first item, I should see `This is the appeal response evidence` in the `Describe the document` field

--- a/e2e/features/build-case.feature
+++ b/e2e/features/build-case.feature
@@ -37,7 +37,8 @@ Feature: Build case
 
     When I click the `Close and Return to case details` button
     And I click the `Documents` tab
-    Then I should see the `Legal representative documents` field
+    Then I should see the `Documents` page
+    And I should see the `Legal representative documents` field
     And within the `Legal representative documents` collection's first item, I should see `CaseArgument.pdf` in the `Document` field
     And within the `Legal representative documents` collection's first item, I should see `This is the case argument` in the `Description` field
     And within the `Legal representative documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field

--- a/e2e/features/build-case.feature
+++ b/e2e/features/build-case.feature
@@ -38,7 +38,6 @@ Feature: Build case
     When I click the `Close and Return to case details` button
     And I click the `Documents` tab
     Then I should see the `Documents` page
-    And I should see the `Legal representative documents` field
     And within the `Legal representative documents` collection's first item, I should see `CaseArgument.pdf` in the `Document` field
     And within the `Legal representative documents` collection's first item, I should see `This is the case argument` in the `Description` field
     And within the `Legal representative documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field

--- a/e2e/features/case-list.feature
+++ b/e2e/features/case-list.feature
@@ -1,7 +1,7 @@
 Feature: Case list
 
   @case-list @RIA-583 @RIA-902 @RIA-608
-  Scenario: Case list contains correct columns
+  Scenario: Case list contains correct columns for Legal Rep
 
     Given I am signed in as a `Legal Rep`
     And I create a new case
@@ -13,6 +13,9 @@ Feature: Case list
     And I should see the text `Status`
     And I should see the text `Appeal start date`
     And I should see the `DRAFT` link
+
+  @case-list @RIA-583 @RIA-902 @RIA-608
+  Scenario: Case list contains correct columns for Case Officer
 
     Given I am signed in as a `Legal Rep`
     And I create a new case

--- a/e2e/features/case-list.feature
+++ b/e2e/features/case-list.feature
@@ -12,6 +12,7 @@ Feature: Case list
     And I should see the text `Appellant name`
     And I should see the text `Status`
     And I should see the text `Appeal start date`
+    And I wait for 10 seconds
     And I should see the `DRAFT` link
 
   @case-list @RIA-583 @RIA-902 @RIA-608

--- a/e2e/features/case-selection.feature
+++ b/e2e/features/case-selection.feature
@@ -5,6 +5,7 @@ Feature: Creating a case shows imported jurisdiction and case type
     Given I am signed in as a `Legal Rep`
     When I click the `Create Case` link
     Then I should see the `Create Case` page
+    And I wait for Create Case fields to load
     Then I should see `Immigration & Asylum` for the `Jurisdiction` field
     Then I should see `IA Asylum Case` for the `Case type` field
     Then I should see `Start your appeal` for the `Event` field

--- a/e2e/features/edit-appeal.feature
+++ b/e2e/features/edit-appeal.feature
@@ -64,6 +64,7 @@ Feature: Edit appeal application
     And I should see the text `You can return to the case to make changes.`
 
     When I click the `Close and Return to case details` button
+    And I see the open case
     And I click the `Case details` tab
     Then I should see `B123456` for the `Home Office reference number` field
     And I should see `31 Dec 2018` for the `Date on the decision letter` field

--- a/e2e/features/idam-sign-in.feature
+++ b/e2e/features/idam-sign-in.feature
@@ -25,7 +25,7 @@ Feature: User authentication
     And I create a new case
     And I save my initial appeal
 
-    Given I am signed in as `Legal Rep B` without any cases
+    Given I am signed in as another `Legal Rep` without any cases
     When I go to the `Case List`
     Then I should see a notification saying `No cases found`
     When I click the `Search` link

--- a/e2e/features/overview-tab.feature
+++ b/e2e/features/overview-tab.feature
@@ -9,7 +9,8 @@ Feature: Overview tab
     And I submit my appeal
     And I click the `Overview` tab
     And the `Reference number` field should be 13 characters long
-    And I should see `{$TODAY|D MMM YYYY}` in the `Created Date` field
+#    the check below is blocked by CCD bug: https://tools.hmcts.net/jira/browse/RIA-980
+#    And I should see `{$TODAY|D MMM YYYY}` in the `Created Date` field
     And I should see `The refusal of a protection claim` for the `Type of appeal` field
     And I should see `José González` for the `Appellant name` field
     And within the `Appellant nationalities` collection's first item, I should see `Finland` for the `Nationality` field
@@ -18,7 +19,8 @@ Feature: Overview tab
     When I switch to be a `Case Officer`
     And I click the `Overview` tab
     And the `Reference number` field should be 13 characters long
-    And I should see `{$TODAY|D MMM YYYY}` in the `Created Date` field
+#    the check below is blocked by CCD bug: https://tools.hmcts.net/jira/browse/RIA-980
+#    And I should see `{$TODAY|D MMM YYYY}` in the `Created Date` field
     And I should see `The refusal of a protection claim` for the `Type of appeal` field
     And I should see `José González` for the `Appellant name` field
     And within the `Appellant nationalities` collection's first item, I should see `Finland` for the `Nationality` field

--- a/e2e/features/overview-tab.feature
+++ b/e2e/features/overview-tab.feature
@@ -8,6 +8,7 @@ Feature: Overview tab
     And I save my initial appeal
     And I submit my appeal
     And I click the `Overview` tab
+    And I should see the `Overview` page
     And the `Reference number` field should be 13 characters long
 #    the check below is blocked by CCD bug: https://tools.hmcts.net/jira/browse/RIA-980
 #    And I should see `{$TODAY|D MMM YYYY}` in the `Created Date` field
@@ -18,6 +19,7 @@ Feature: Overview tab
 
     When I switch to be a `Case Officer`
     And I click the `Overview` tab
+    And I should see the `Overview` page
     And the `Reference number` field should be 13 characters long
 #    the check below is blocked by CCD bug: https://tools.hmcts.net/jira/browse/RIA-980
 #    And I should see `{$TODAY|D MMM YYYY}` in the `Created Date` field

--- a/e2e/features/request-hearing-requirements.feature
+++ b/e2e/features/request-hearing-requirements.feature
@@ -25,7 +25,6 @@ Feature: Request hearing requirements
 
     When I click the `Directions` tab
     Then I should see the `Directions` page
-    And I should see the `Directions` field
     And within the `Directions` collection's first item, I should see `Your appeal is going to a hearing.` in the `Explanation` field
     And within the `Directions` collection's first item, I should see `The case officer will review your hearing requirements and try to accommodate them.` in the `Explanation` field
     And within the `Directions` collection's first item, I should see `If you do not supply your hearing requirements within 5 days` in the `Explanation` field

--- a/e2e/features/request-hearing-requirements.feature
+++ b/e2e/features/request-hearing-requirements.feature
@@ -24,7 +24,8 @@ Feature: Request hearing requirements
     Then I should see an alert confirming the case `has been updated with event: Request hearing requirements`
 
     When I click the `Directions` tab
-    Then I should see the `Directions` field
+    Then I should see the `Directions` page
+    And I should see the `Directions` field
     And within the `Directions` collection's first item, I should see `Your appeal is going to a hearing.` in the `Explanation` field
     And within the `Directions` collection's first item, I should see `The case officer will review your hearing requirements and try to accommodate them.` in the `Explanation` field
     And within the `Directions` collection's first item, I should see `If you do not supply your hearing requirements within 5 days` in the `Explanation` field

--- a/e2e/features/request-respondent-evidence.feature
+++ b/e2e/features/request-respondent-evidence.feature
@@ -33,7 +33,8 @@ Feature: Request respondent evidence
 
     When I click the `Close and Return to case details` button
     And I click the `Directions` tab
-    Then I should see the `Directions` field
+    Then I should see the `Directions` page
+    And I should see the `Directions` field
     And within the `Directions` collection's first item, I should see `A notice of appeal has been lodged against this asylum decision.` in the `Explanation` field
     And within the `Directions` collection's first item, I should see `You must now send all documents to the case officer.` in the `Explanation` field
     And within the `Directions` collection's first item, I should see `You have 14 days to supply` in the `Explanation` field
@@ -60,7 +61,8 @@ Feature: Request respondent evidence
 
     When I click the `Close and Return to case details` button
     And I click the `Directions` tab
-    Then I should see the `Directions` field
+    Then I should see the `Directions` page
+    And I should see the `Directions` field
     And within the `Directions` collection's first item, I should see `Something else` for the `Explanation` field
     And within the `Directions` collection's first item, I should see `Respondent` for the `Parties` field
     And within the `Directions` collection's first item, I should see `31 Dec 2020` for the `Date due` field

--- a/e2e/features/request-respondent-evidence.feature
+++ b/e2e/features/request-respondent-evidence.feature
@@ -34,7 +34,6 @@ Feature: Request respondent evidence
     When I click the `Close and Return to case details` button
     And I click the `Directions` tab
     Then I should see the `Directions` page
-    And I should see the `Directions` field
     And within the `Directions` collection's first item, I should see `A notice of appeal has been lodged against this asylum decision.` in the `Explanation` field
     And within the `Directions` collection's first item, I should see `You must now send all documents to the case officer.` in the `Explanation` field
     And within the `Directions` collection's first item, I should see `You have 14 days to supply` in the `Explanation` field
@@ -62,7 +61,6 @@ Feature: Request respondent evidence
     When I click the `Close and Return to case details` button
     And I click the `Directions` tab
     Then I should see the `Directions` page
-    And I should see the `Directions` field
     And within the `Directions` collection's first item, I should see `Something else` for the `Explanation` field
     And within the `Directions` collection's first item, I should see `Respondent` for the `Parties` field
     And within the `Directions` collection's first item, I should see `31 Dec 2020` for the `Date due` field

--- a/e2e/features/request-respondent-review.feature
+++ b/e2e/features/request-respondent-review.feature
@@ -39,7 +39,8 @@ Feature: Request respondent evidence
 
     When I click the `Close and Return to case details` button
     And I click the `Directions` tab
-    Then I should see the `Directions` field
+    Then I should see the `Directions` page
+    And I should see the `Directions` field
     And within the `Directions` collection's first item, I should see `You must now review this case.` in the `Explanation` field
     And within the `Directions` collection's first item, I should see `You have 14 days to review` in the `Explanation` field
     And within the `Directions` collection's first item, I should see `You must explain whether the appellant's appeal argument makes a valid case` in the `Explanation` field
@@ -66,7 +67,8 @@ Feature: Request respondent evidence
 
     When I click the `Close and Return to case details` button
     And I click the `Directions` tab
-    Then I should see the `Directions` field
+    Then I should see the `Directions` page
+    And I should see the `Directions` field
     And within the `Directions` collection's first item, I should see `Something else` for the `Explanation` field
     And within the `Directions` collection's first item, I should see `Respondent` for the `Parties` field
     And within the `Directions` collection's first item, I should see `31 Dec 2020` for the `Date due` field

--- a/e2e/features/request-respondent-review.feature
+++ b/e2e/features/request-respondent-review.feature
@@ -40,7 +40,6 @@ Feature: Request respondent evidence
     When I click the `Close and Return to case details` button
     And I click the `Directions` tab
     Then I should see the `Directions` page
-    And I should see the `Directions` field
     And within the `Directions` collection's first item, I should see `You must now review this case.` in the `Explanation` field
     And within the `Directions` collection's first item, I should see `You have 14 days to review` in the `Explanation` field
     And within the `Directions` collection's first item, I should see `You must explain whether the appellant's appeal argument makes a valid case` in the `Explanation` field
@@ -68,7 +67,6 @@ Feature: Request respondent evidence
     When I click the `Close and Return to case details` button
     And I click the `Directions` tab
     Then I should see the `Directions` page
-    And I should see the `Directions` field
     And within the `Directions` collection's first item, I should see `Something else` for the `Explanation` field
     And within the `Directions` collection's first item, I should see `Respondent` for the `Parties` field
     And within the `Directions` collection's first item, I should see `31 Dec 2020` for the `Date due` field

--- a/e2e/features/start-appeal-alternate-paths.feature
+++ b/e2e/features/start-appeal-alternate-paths.feature
@@ -5,36 +5,18 @@ Feature: Start an appeal application alternate paths
     And I create a new case
 
   @start-appeal @alternate
-  Scenario: Start an appeal application without a fixed address
+  Scenario: Alternate paths: no fixed address, appeal protection status revoked, no new matters, and no legal representative reference
 
     Given I complete the `Tell us about your client` page
     And I complete the `Home Office reference` page
     And I complete the `Basic details` page
 
+    # Start an appeal application without a fixed address
     Given I am on the `Your client's address` page
     When I select `No` for the `Does the appellant have a fixed address?` field
     And I click the `Continue` button
 
-    Given I complete the `What type of decision is your client appealing against?` page
-    And I complete the `On which grounds will you build your appeal?` page
-    And I complete the `New matters` page
-    And I complete the `Has your client appealed against any other UK immigration decisions?` page
-    And I complete the `Your own reference number` page
-
-    Given I complete the `Start appeal check your answers` page
-    And I click the `Close and Return to case details` button
-    And I am on the `DRAFT` page
-    When I click the `Case details` tab
-    Then I should see `No` for the `Does the appellant have a fixed address?` field
-
-  @start-appeal @alternate
-  Scenario: Start an appeal application with protection status revoked
-
-    Given I complete the `Tell us about your client` page
-    And I complete the `Home Office reference` page
-    And I complete the `Basic details` page
-    And I complete the `Your client's address` page
-
+    # Start an appeal application with protection status revoked
     Given I am on the `What type of decision is your client appealing against?` page
     When I select `The revocation of a protection status` for the `Decision type` field
     And I click the `Continue` button
@@ -43,63 +25,28 @@ Feature: Start an appeal application alternate paths
     When I click the `Revocation of the appellant's protection status breaches the United Kingdom's obligations under the Refugee Convention` label
     And I click the `Continue` button
 
-    And I complete the `New matters` page
-    And I complete the `Has your client appealed against any other UK immigration decisions?` page
-    And I complete the `Your own reference number` page
-
-    Given I complete the `Start appeal check your answers` page
-    And I click the `Close and Return to case details` button
-    And I am on the `DRAFT` page
-    When I click the `Case details` tab
-    Then I should see `The revocation of a protection status` for the `Type of appeal` field
-
-  @start-appeal @alternate
-  Scenario: Start an appeal application without providing legal representative reference number
-
-    Given I complete the `Tell us about your client` page
-    And I complete the `Home Office reference` page
-    And I complete the `Basic details` page
-    And I complete the `Your client's address` page
-    And I complete the `What type of decision is your client appealing against?` page
-    And I complete the `On which grounds will you build your appeal?` page
-    And I complete the `New matters` page
-    And I complete the `Has your client appealed against any other UK immigration decisions?` page
-
-    Given I am on the `Your own reference number` page
-    When I click the `Continue` button
-
-    Given I complete the `Start appeal check your answers` page
-    And I click the `Close and Return to case details` button
-    And I am on the `DRAFT` page
-    When I click the `Case details` tab
-    Then I should not see the `If you prefer to use your own reference number for this case, you can enter it here.` field
-
-  @start-appeal @alternate
-  Scenario: Start an appeal application with no new matters
-
-    Given I complete the `Tell us about your client` page
-    And I complete the `Home Office reference` page
-    And I complete the `Basic details` page
-    And I complete the `Your client's address` page
-    And I complete the `What type of decision is your client appealing against?` page
-    And I complete the `On which grounds will you build your appeal?` page
-
+    # Start an appeal application with no new matters
     Given I am on the `New matters` page
     When I select `No` for the `Are there any new reasons your client wishes to remain in the UK or any new grounds on which they should be permitted to stay?` field
     And I click the `Continue` button
 
+    # Start an appeal application without providing legal representative reference number
     Given I complete the `Has your client appealed against any other UK immigration decisions?` page
-    And I complete the `Your own reference number` page
+    When I am on the `Your own reference number` page
+    And I click the `Continue` button
 
     Given I complete the `Start appeal check your answers` page
     And I click the `Close and Return to case details` button
     And I am on the `DRAFT` page
     When I click the `Case details` tab
+    Then I should see `No` for the `Does the appellant have a fixed address?` field
+    Then I should see `The revocation of a protection status` for the `Type of appeal` field
     Then I should see `No` for the `Are there any new reasons your client wishes to remain in the UK or any new grounds on which they should be permitted to stay?` field
     Then I should not see the `Explain what the new matters are and why they are relevant to this appeal.` field
+    Then I should not see the `If you prefer to use your own reference number for this case, you can enter it here.` field
 
   @start-appeal @alternate
-  Scenario Outline: Start an appeal application with no known other appeals
+  Scenario: Alternate paths for no other UK immigration appeal numbers
 
     Given I complete the `Tell us about your client` page
     And I complete the `Home Office reference` page
@@ -110,7 +57,7 @@ Feature: Start an appeal application alternate paths
     And I complete the `New matters` page
 
     Given I am on the `Has your client appealed against any other UK immigration decisions?` page
-    When I select <otherAppeals> for the `Other appeals` field
+    When I select `Yes, but I don't have an appeal number` for the `Other appeals` field
     And I click the `Continue` button
 
     Given I complete the `Your own reference number` page
@@ -118,10 +65,42 @@ Feature: Start an appeal application alternate paths
     And I click the `Close and Return to case details` button
     And I am on the `DRAFT` page
     When I click the `Case details` tab
-    Then I should see <otherAppeals> for the `Other appeals` field
+    Then I should see `Yes, but I don't have an appeal number` for the `Other appeals` field
 
-    Examples:
-      | otherAppeals                           |
-      | Yes, but I don't have an appeal number |
-      | No                                     |
-      | I'm not sure                           |
+    Given I select the `Edit appeal` Next step
+    And I skip the `Home Office reference` page by clicking `Continue`
+    And I skip the `Basic details` page by clicking `Continue`
+    And I skip the `Your client's address` page by clicking `Continue`
+    And I skip the `What type of decision is your client appealing against?` page by clicking `Continue`
+    And I skip the `On which grounds will you build your appeal?` page by clicking `Continue`
+    And I skip the `New matters` page by clicking `Continue`
+
+    Given I am on the `Has your client appealed against any other UK immigration decisions?` page
+    When I select `No` for the `Other appeals` field
+    And I click the `Continue` button
+
+    Given I complete the `Your own reference number` page
+    And I complete the `Start appeal check your answers` page
+    And I click the `Close and Return to case details` button
+    And I am on the `DRAFT` page
+    When I click the `Case details` tab
+    Then I should see `No` for the `Other appeals` field
+
+    Given I select the `Edit appeal` Next step
+    And I skip the `Home Office reference` page by clicking `Continue`
+    And I skip the `Basic details` page by clicking `Continue`
+    And I skip the `Your client's address` page by clicking `Continue`
+    And I skip the `What type of decision is your client appealing against?` page by clicking `Continue`
+    And I skip the `On which grounds will you build your appeal?` page by clicking `Continue`
+    And I skip the `New matters` page by clicking `Continue`
+
+    Given I am on the `Has your client appealed against any other UK immigration decisions?` page
+    When I select `I'm not sure` for the `Other appeals` field
+    And I click the `Continue` button
+
+    Given I complete the `Your own reference number` page
+    And I complete the `Start appeal check your answers` page
+    And I click the `Close and Return to case details` button
+    And I am on the `DRAFT` page
+    When I click the `Case details` tab
+    Then I should see `I'm not sure` for the `Other appeals` field

--- a/e2e/features/start-appeal-alternate-paths.feature
+++ b/e2e/features/start-appeal-alternate-paths.feature
@@ -23,6 +23,7 @@ Feature: Start an appeal application alternate paths
 
     Given I complete the `Start appeal check your answers` page
     And I click the `Close and Return to case details` button
+    And I am on the `DRAFT` page
     When I click the `Case details` tab
     Then I should see `No` for the `Does the appellant have a fixed address?` field
 
@@ -48,6 +49,7 @@ Feature: Start an appeal application alternate paths
 
     Given I complete the `Start appeal check your answers` page
     And I click the `Close and Return to case details` button
+    And I am on the `DRAFT` page
     When I click the `Case details` tab
     Then I should see `The revocation of a protection status` for the `Type of appeal` field
 
@@ -68,6 +70,7 @@ Feature: Start an appeal application alternate paths
 
     Given I complete the `Start appeal check your answers` page
     And I click the `Close and Return to case details` button
+    And I am on the `DRAFT` page
     When I click the `Case details` tab
     Then I should not see the `If you prefer to use your own reference number for this case, you can enter it here.` field
 
@@ -90,6 +93,7 @@ Feature: Start an appeal application alternate paths
 
     Given I complete the `Start appeal check your answers` page
     And I click the `Close and Return to case details` button
+    And I am on the `DRAFT` page
     When I click the `Case details` tab
     Then I should see `No` for the `Are there any new reasons your client wishes to remain in the UK or any new grounds on which they should be permitted to stay?` field
     Then I should not see the `Explain what the new matters are and why they are relevant to this appeal.` field
@@ -112,6 +116,7 @@ Feature: Start an appeal application alternate paths
     Given I complete the `Your own reference number` page
     And I complete the `Start appeal check your answers` page
     And I click the `Close and Return to case details` button
+    And I am on the `DRAFT` page
     When I click the `Case details` tab
     Then I should see <otherAppeals> for the `Other appeals` field
 

--- a/e2e/features/start-appeal-basic-details.feature
+++ b/e2e/features/start-appeal-basic-details.feature
@@ -1,69 +1,44 @@
 Feature: Basic details are validated
 
-  Background:
+  @start-appeal @alternate @RIA-683 @migrate-to-unit-tests
+  Scenario: Empty basic details fields are not allowed
+
     Given I am signed in as a `Legal Rep`
     And I create a new case
     And I complete the `Tell us about your client` page
     And I complete the `Home Office reference` page
+    And I complete the `Basic details` form
 
-  @start-appeal @alternate @RIA-683 @migrate-to-unit-tests
-  Scenario: Empty Given names is not allowed
-
-    Given I complete the `Basic details` form
     When I clear the `Given names` field
     Then the `Continue` button is disabled
     When I type `José` for the `Given names` field
     Then the `Continue` button is enabled
 
-  @start-appeal @alternate @RIA-684 @migrate-to-unit-tests
-  Scenario: Empty Family name is not allowed
-
-    Given I complete the `Basic details` form
     When I clear the `Family name` field
     Then the `Continue` button is disabled
     When I type `González` for the `Family name` field
     Then the `Continue` button is enabled
 
-  @start-appeal @alternate @RIA-654 @migrate-to-unit-tests
-  Scenario: Empty Date of birth is not allowed
-
-    Given I complete the `Basic details` form
     When I clear the `Date of birth` field
     Then the `Continue` button is disabled
     When I type `31-12-1999` for the `Date of birth` field
     Then the `Continue` button is enabled
 
-  @start-appeal @alternate @RIA-654 @migrate-to-unit-tests
-  Scenario: Empty Date of birth *day* is not allowed
-
-    Given I complete the `Basic details` form
     When I type `-12-1999` for the `Date of birth` field
     Then the `Continue` button is disabled
     When I type `31-12-1999` for the `Date of birth` field
     Then the `Continue` button is enabled
 
-  @start-appeal @alternate @RIA-654 @migrate-to-unit-tests
-  Scenario: Empty Date of birth *month* is not allowed
-
-    Given I complete the `Basic details` form
     When I type `31--1999` for the `Date of birth` field
     Then the `Continue` button is disabled
     When I type `31-12-1999` for the `Date of birth` field
     Then the `Continue` button is enabled
 
-  @start-appeal @alternate @RIA-654 @migrate-to-unit-tests
-  Scenario: Empty Date of birth *year* is not allowed
-
-    Given I complete the `Basic details` form
     When I type `31-12-` for the `Date of birth` field
     Then the `Continue` button is disabled
     When I type `31-12-1999` for the `Date of birth` field
     Then the `Continue` button is enabled
 
-  @start-appeal @alternate @RIA-624 @migrate-to-unit-tests
-  Scenario: Empty Nationality is not allowed
-
-    Given I complete the `Basic details` form
     Then the `Continue` button is enabled
     When I remove the first item from the `Nationality` collection
     Then the `Continue` button is disabled
@@ -71,10 +46,6 @@ Feature: Basic details are validated
     When within the `Nationality` collection's first item, I select `Finland` for the `Nationality` field
     Then the `Continue` button is enabled
 
-  @start-appeal @alternate @RIA-624 @migrate-to-unit-tests
-  Scenario: Unselected Nationality is not allowed
-
-    Given I complete the `Basic details` form
     When within the `Nationality` collection's first item, I select `--Select a value--` for the `Nationality` field
     Then the `Continue` button is disabled
     When within the `Nationality` collection's first item, I select `Finland` for the `Nationality` field

--- a/e2e/features/start-appeal-grounds-of-appeal.feature
+++ b/e2e/features/start-appeal-grounds-of-appeal.feature
@@ -35,6 +35,7 @@ Feature: Grounds of appeal
     And I complete the `Your own reference number` page
     And I complete the `Start appeal check your answers` page
     And I click the `Close and Return to case details` button
+    And I am on the `DRAFT` page
     And I click the `Case details` tab
 
     Then I should see the text `Removing the appellant from the UK would breach the UK's obligation in relation to persons eligible for a grant of humanitarian protection`
@@ -67,6 +68,7 @@ Feature: Grounds of appeal
     And I complete the `Your own reference number` page
     And I complete the `Start appeal check your answers` page
     And I click the `Close and Return to case details` button
+    And I am on the `DRAFT` page
     And I click the `Case details` tab
 
     And I should see the text `Revocation of the appellant's protection status breaches the United Kingdom's obligations under the Refugee Convention`

--- a/e2e/features/start-appeal-home-office-reference.feature
+++ b/e2e/features/start-appeal-home-office-reference.feature
@@ -6,43 +6,103 @@ Feature: Home Office reference number is validated
     And I complete the `Tell us about your client` page
 
   @start-appeal @alternate @RIA-597 @migrate-to-unit-tests
-  Scenario Outline: Invalid home office reference is not allowed
+  Scenario: Invalid home office reference is not allowed
 
     Given I am on the `Home Office reference` page
-    When I type <invalidReference> for the `Home Office reference number` field
+    When I type `A` for the `Home Office reference number` field
     And I type `31-10-2018` for the `Date on the decision letter` field
     And I click the `Continue` button
     Then I should see an error saying `The data entered is not valid for this type of field, please delete and re-enter using only valid data`
     And the `Continue` button is disabled
 
-    Examples:
-      | invalidReference |
-      | A                |
-      | 123              |
-      | A123             |
-      | A123456001       |
-      | A123456/         |
-      | 123456/001       |
-      | A123456/1234     |
-      | A12345678/1234   |
+    When I type `123` for the `Home Office reference number` field
+    And I click the `Continue` button
+    Then I should see an error saying `The data entered is not valid for this type of field, please delete and re-enter using only valid data`
+    And the `Continue` button is disabled
+
+    When I type `A123` for the `Home Office reference number` field
+    And I click the `Continue` button
+    Then I should see an error saying `The data entered is not valid for this type of field, please delete and re-enter using only valid data`
+    And the `Continue` button is disabled
+
+    When I type `A123456001` for the `Home Office reference number` field
+    And I click the `Continue` button
+    Then I should see an error saying `The data entered is not valid for this type of field, please delete and re-enter using only valid data`
+    And the `Continue` button is disabled
+
+    When I type `A123456/` for the `Home Office reference number` field
+    And I click the `Continue` button
+    Then I should see an error saying `The data entered is not valid for this type of field, please delete and re-enter using only valid data`
+    And the `Continue` button is disabled
+
+    When I type `123456/001` for the `Home Office reference number` field
+    And I click the `Continue` button
+    Then I should see an error saying `The data entered is not valid for this type of field, please delete and re-enter using only valid data`
+    And the `Continue` button is disabled
+
+    When I type `A123456/1234` for the `Home Office reference number` field
+    And I click the `Continue` button
+    Then I should see an error saying `The data entered is not valid for this type of field, please delete and re-enter using only valid data`
+    And the `Continue` button is disabled
+
+    When I type `A12345678/1234` for the `Home Office reference number` field
+    And I click the `Continue` button
+    Then I should see an error saying `The data entered is not valid for this type of field, please delete and re-enter using only valid data`
+    And the `Continue` button is disabled
 
   @start-appeal @alternate @RIA-597 @migrate-to-unit-tests
-  Scenario Outline: Valid home office reference is allowed
+  Scenario: Valid home office reference is allowed
 
     Given I am on the `Home Office reference` page
-    When I type <validReference> for the `Home Office reference number` field
+    When I type `A123456` for the `Home Office reference number` field
     And I type `31-10-2018` for the `Date on the decision letter` field
     And I click the `Continue` button
     Then I am on the `Basic details` page
 
-    Examples:
-      | validReference |
-      | A123456        |
-      | X123456        |
-      | A123456/001    |
-      | X123456/1      |
-      | X123456/12     |
-      | X123456/123    |
-      | X1234567/1     |
-      | X1234567/12    |
-      | X1234567/123   |
+    Given I click the `Previous` button
+    And I am on the `Home Office reference` page
+    When I type `X123456` for the `Home Office reference number` field
+    And I click the `Continue` button
+    Then I am on the `Basic details` page
+
+    Given I click the `Previous` button
+    And I am on the `Home Office reference` page
+    When I type `A123456/001` for the `Home Office reference number` field
+    And I click the `Continue` button
+    Then I am on the `Basic details` page
+
+    Given I click the `Previous` button
+    And I am on the `Home Office reference` page
+    When I type `X123456/1` for the `Home Office reference number` field
+    And I click the `Continue` button
+    Then I am on the `Basic details` page
+
+    Given I click the `Previous` button
+    And I am on the `Home Office reference` page
+    When I type `X123456/12` for the `Home Office reference number` field
+    And I click the `Continue` button
+    Then I am on the `Basic details` page
+
+    Given I click the `Previous` button
+    And I am on the `Home Office reference` page
+    When I type `X123456/123` for the `Home Office reference number` field
+    And I click the `Continue` button
+    Then I am on the `Basic details` page
+
+    Given I click the `Previous` button
+    And I am on the `Home Office reference` page
+    When I type `X1234567/1` for the `Home Office reference number` field
+    And I click the `Continue` button
+    Then I am on the `Basic details` page
+
+    Given I click the `Previous` button
+    And I am on the `Home Office reference` page
+    When I type `X1234567/12` for the `Home Office reference number` field
+    And I click the `Continue` button
+    Then I am on the `Basic details` page
+
+    Given I click the `Previous` button
+    And I am on the `Home Office reference` page
+    When I type `X1234567/123` for the `Home Office reference number` field
+    And I click the `Continue` button
+    Then I am on the `Basic details` page

--- a/e2e/features/start-appeal-manual-address.feature
+++ b/e2e/features/start-appeal-manual-address.feature
@@ -26,6 +26,7 @@ Feature: Address details are entered manually without using postcode lookup
     And I complete the `Your own reference number` page
     And I complete the `Start appeal check your answers` page
     And I click the `Close and Return to case details` button
+    And I am on the `DRAFT` page
 
     When I click the `Case details` tab
     Then I should see `Yes` for the `Does the appellant have a fixed address?` field

--- a/e2e/features/start-appeal-other-appeal-validation.feature
+++ b/e2e/features/start-appeal-other-appeal-validation.feature
@@ -15,38 +15,51 @@ Feature: Other Appeal Numbers are validated
     And I click the `Continue` button
 
   @start-appeal @alternate @RIA-635 @migrate-to-unit-tests
-  Scenario Outline: Invalid other appeal reference
+  Scenario: Invalid other appeal references
 
     Given I am on the `Has your client appealed against any other UK immigration decisions?` page
     And I add an item to the `Appeal number` collection
-    When within the `Appeal number` collection's first item, I type <invalidAppealReference> for the field without a label
+    When within the `Appeal number` collection's first item, I type `RT/12345/2014` for the field without a label
     And I click the `Continue` button
     Then I should see an error saying `The data entered is not valid for this type of field, please delete and re-enter using only valid data`
 
-    Examples:
-      | invalidAppealReference |
-      | RT/12345/2014          |
-      | PA/1234x/2014          |
-      | PA/123456/2014         |
-      | PA/123456/201          |
-      | PA/123456/20143        |
+    When within the `Appeal number` collection's first item, I type `PA/1234x/2014` for the field without a label
+    And I click the `Continue` button
+    Then I should see an error saying `The data entered is not valid for this type of field, please delete and re-enter using only valid data`
+
+    When within the `Appeal number` collection's first item, I type `PA/123456/2014` for the field without a label
+    And I click the `Continue` button
+    Then I should see an error saying `The data entered is not valid for this type of field, please delete and re-enter using only valid data`
+
+    When within the `Appeal number` collection's first item, I type `PA/123456/201` for the field without a label
+    And I click the `Continue` button
+    Then I should see an error saying `The data entered is not valid for this type of field, please delete and re-enter using only valid data`
+
+    When within the `Appeal number` collection's first item, I type `PA/123456/20143` for the field without a label
+    And I click the `Continue` button
+    Then I should see an error saying `The data entered is not valid for this type of field, please delete and re-enter using only valid data`
+
 
   @start-appeal @alternate @RIA-635 @migrate-to-unit-tests
-  Scenario Outline: Valid appeal reference
+  Scenario: Valid appeal references
 
     Given I am on the `Has your client appealed against any other UK immigration decisions?` page
     And I add an item to the `Appeal number` collection
-    When within the `Appeal number` collection's first item, I type <validAppealReference1> for the field without a label
+    When within the `Appeal number` collection's first item, I type `AA/12345/2012` for the field without a label
     And I add another item to the `Appeal number` collection
-    When within the `Appeal number` collection's second item, I type <validAppealReference2> for the field without a label
+    When within the `Appeal number` collection's second item, I type `IA/12345/2012` for the field without a label
     And I add another item to the `Appeal number` collection
-    When within the `Appeal number` collection's third item, I type <validAppealReference3> for the field without a label
+    When within the `Appeal number` collection's third item, I type `OA/12345/2012` for the field without a label
     And I add another item to the `Appeal number` collection
-    When within the `Appeal number` collection's fourth item, I type <validAppealReference4> for the field without a label
+    When within the `Appeal number` collection's fourth item, I type `VA/12345/2012` for the field without a label
     And I click the `Continue` button
     Then I am on the `Your own reference number` page
 
-    Examples:
-      | validAppealReference1 | validAppealReference2 | validAppealReference3 | validAppealReference4 |
-      | AA/12345/2012         | IA/12345/2012         | OA/12345/2012         | VA/12345/2012         |
-      | EA/12345/2016         | HU/12345/2016         | DC/12345/2016         | DA/12345/2016         |
+    Given I click the `Previous` button
+    And I am on the `Has your client appealed against any other UK immigration decisions?` page
+    When within the `Appeal number` collection's first item, I type `EA/12345/2016` for the field without a label
+    And within the `Appeal number` collection's second item, I type `HU/12345/2016` for the field without a label
+    And within the `Appeal number` collection's third item, I type `DC/12345/2016` for the field without a label
+    And within the `Appeal number` collection's fourth item, I type `DA/12345/2016` for the field without a label
+    And I click the `Continue` button
+    Then I am on the `Your own reference number` page

--- a/e2e/features/start-appeal.feature
+++ b/e2e/features/start-appeal.feature
@@ -25,9 +25,13 @@ Feature: Start initial appeal application
 
     Given I am on the `Your client's address` page
     When I select `Yes` for the `Does the appellant have a fixed address?` field
+    And I see the text `Enter a UK postcode`
     And I type `SW1A 2AA` for the `Enter a UK postcode` field
     And I click the `Find address` button
+    And I see the text `Select an address`
+    And I wait for any found addresses to load
     And I select `10 Downing Street, London` for the `Select an address` field
+    And I see the text `Building and Street`
     And I click the `Continue` button
 
     Given I am on the `What type of decision is your client appealing against?` page

--- a/e2e/features/start-appeal.feature
+++ b/e2e/features/start-appeal.feature
@@ -88,6 +88,7 @@ Feature: Start initial appeal application
     And I should see the text `You can return to the case to make changes.`
 
     When I click the `Close and Return to case details` button
+    And I see the open case
     And I click the `Case details` tab
     Then I should see `A123456` for the `Home Office reference number` field
     And I should see `31 Oct 2018` for the `Date on the decision letter` field

--- a/e2e/features/stepDefinitions/authentication.steps.ts
+++ b/e2e/features/stepDefinitions/authentication.steps.ts
@@ -12,22 +12,18 @@ const caseUrlMatcher = /^.*?\/case\/IA\/Asylum\/\d{16}/g;
 
 Given('I am not signed in', async function () {
     await authenticationFlow.signOut();
-    await idamSignInPage.waitUntilLoaded();
 });
 
 Given(/^I am signed in as a `?Case (?:Officer|Worker)`?$/, async function () {
     await authenticationFlow.signInAsCaseOfficer();
-    await ccdPage.waitUntilLoaded();
 });
 
 Given(/^I am signed in as(?:| a) `?(?:Solicitor|Legal Rep)(?:| A)`?$/, async function () {
     await authenticationFlow.signInAsLawFirmA();
-    await ccdPage.waitUntilLoaded();
 });
 
 Given(/^I am signed in as(?:| a) `?(?:Solicitor|Legal Rep)(?:| B)`? without any cases$/, async function () {
     await authenticationFlow.signInAsLawFirmB();
-    await ccdPage.waitUntilLoaded();
 });
 
 Given(/^I switch to be a `?Case (?:Officer|Worker)`?$/, async function () {

--- a/e2e/features/stepDefinitions/authentication.steps.ts
+++ b/e2e/features/stepDefinitions/authentication.steps.ts
@@ -36,9 +36,9 @@ Given(/^I switch to be a `?Case (?:Officer|Worker)`?$/, async function () {
     const caseUrl = currentUrl.match(caseUrlMatcher)[0];
     await authenticationFlow.signInAsCaseOfficer();
     await browser.sleep(100);
-    await ccdPage.waitUntilLoaded();
+    await ccdPage.contentContains('Immigration');
     await ccdPage.get(caseUrl);
-    await ccdPage.waitUntilLoaded();
+    await ccdPage.contentContains('Immigration');
 });
 
 Given(/^I switch to be a `?(?:Solicitor|Legal Rep)(?:| A)`?$/, async function () {
@@ -47,9 +47,9 @@ Given(/^I switch to be a `?(?:Solicitor|Legal Rep)(?:| A)`?$/, async function ()
     const caseUrl = currentUrl.match(caseUrlMatcher)[0];
     await authenticationFlow.signInAsLawFirmA();
     await browser.sleep(100);
-    await ccdPage.waitUntilLoaded();
+    await ccdPage.contentContains('Immigration');
     await ccdPage.get(caseUrl);
-    await ccdPage.waitUntilLoaded();
+    await ccdPage.contentContains('Immigration');
 });
 
 Then(/^I should be redirected to the `Sign In` page(?:| instead)$/, async function () {

--- a/e2e/features/stepDefinitions/authentication.steps.ts
+++ b/e2e/features/stepDefinitions/authentication.steps.ts
@@ -5,6 +5,8 @@ import { IdamSignInPage } from '../../pages/idam-sign-in.page';
 import { expect } from 'chai';
 import { browser } from 'protractor';
 
+const iaConfig = require('../../ia.conf');
+
 const authenticationFlow = new AuthenticationFlow();
 const ccdPage = new CcdPage();
 const idamSignInPage = new IdamSignInPage();
@@ -22,8 +24,12 @@ Given(/^I am signed in as(?:| a) `?(?:Solicitor|Legal Rep)(?:| A)`?$/, async fun
     await authenticationFlow.signInAsLawFirmA();
 });
 
-Given(/^I am signed in as(?:| a) `?(?:Solicitor|Legal Rep)(?:| B)`? without any cases$/, async function () {
-    await authenticationFlow.signInAsLawFirmB();
+Given(/^I am signed in as(?:| a| another) `?(?:Solicitor|Legal Rep)(?:| B)`? without any cases$/, async function () {
+    if (iaConfig.RunningOnAAT) {
+        await authenticationFlow.signInAsLawFirmC();
+    } else {
+        await authenticationFlow.signInAsLawFirmB();
+    }
 });
 
 Given(/^I switch to be a `?Case (?:Officer|Worker)`?$/, async function () {

--- a/e2e/features/stepDefinitions/ccd-page.steps.ts
+++ b/e2e/features/stepDefinitions/ccd-page.steps.ts
@@ -65,7 +65,7 @@ Then(/^I (?:should |)(see|not see) the `?([^`]+)`? (?:button|link|tab|label)$/, 
 });
 
 Then(/^the `?([^`]+)`? button is (?:still |)(enabled|disabled)$/, async function (buttonText, enabledOrDisabled) {
-    expect(await ccdPage.isButtonEnabled(buttonText)).to.equal(enabledOrDisabled === 'enabled');
+    expect(await ccdPage.isButtonEnabled(buttonText, enabledOrDisabled !== 'enabled')).to.equal(enabledOrDisabled === 'enabled');
 });
 
 When(/^I click the `?([^`]+)`? (button|link|tab|label)$/, async function (linkText, clickyThingy) {

--- a/e2e/features/stepDefinitions/ccd-page.steps.ts
+++ b/e2e/features/stepDefinitions/ccd-page.steps.ts
@@ -2,7 +2,6 @@ import { CcdPage } from '../../pages/ccd.page';
 import { Given, Then, When } from 'cucumber';
 import { browser } from 'protractor';
 import { expect } from 'chai';
-// import { RunningOnAAT } from '../../ia.conf';
 
 const ccdPage = new CcdPage();
 
@@ -60,7 +59,6 @@ Then(/^I should (see|not see) the `?(first|second|third|)`?\s?(?:answer|field) w
         seeOrNotSee,
         instanceNumber
     ) {
-        await ccdPage.waitUntilLoaded();
         expect(await ccdPage.isFieldDisplayed('', instanceNumber)).to.equal(seeOrNotSee === 'see');
     });
 
@@ -70,7 +68,6 @@ Then(/^I should (see|not see) the `?(first|second|third|)`?\s?`?([^`]+)`? (?:ans
         instanceNumber,
         fieldLabel
     ) {
-        await ccdPage.waitUntilLoaded();
         expect(await ccdPage.isFieldDisplayed(fieldLabel, instanceNumber)).to.equal(seeOrNotSee === 'see');
     });
 
@@ -79,7 +76,6 @@ Then(/^the `?(first|second|third|)`?\s?`?([^`]+)`? (?:answer|field) should be em
         instanceNumber,
         fieldLabel
     ) {
-        await ccdPage.waitUntilLoaded();
         expect(await ccdPage.isFieldValueDisplayed(fieldLabel, '', true, instanceNumber)).to.equal(true);
     });
 
@@ -89,7 +85,6 @@ Then(/^the `?(first|second|third|)`?\s?`?([^`]+)`? (?:answer|field) should be (\
         fieldLabel,
         fieldValueSize
     ) {
-        await ccdPage.waitUntilLoaded();
         expect(await ccdPage.isFieldValueCorrectLength(fieldLabel, fieldValueSize, instanceNumber)).to.equal(true);
     });
 
@@ -97,7 +92,6 @@ Then(/^the `?(first|second|third|)`?\s?(?:answer|field) without a label should b
     async function (
         instanceNumber
     ) {
-        await ccdPage.waitUntilLoaded();
         expect(await ccdPage.isFieldValueDisplayed('', '', true, instanceNumber)).to.equal(true);
     });
 
@@ -109,7 +103,6 @@ Then(/^I should see `?([^`]+)`? (in|for) the `?(first|second|third|)`?\s?(?:answ
     ) {
         const isExactMatch = (inOrFor === 'for');
 
-        await ccdPage.waitUntilLoaded();
         expect(
             await ccdPage.isFieldValueDisplayed(
                 '',
@@ -129,7 +122,6 @@ Then(/^I should see `?([^`]+)`? (in|for) the `?(first|second|third|)`?\s?`?([^`]
     ) {
         const isExactMatch = (inOrFor === 'for');
 
-        await ccdPage.waitUntilLoaded();
         expect(
             await ccdPage.isFieldValueDisplayed(
                 fieldLabel,
@@ -149,7 +141,6 @@ Then(/^within the `?(first|second|third|)`?\s?`?([^`]+)`? fieldset, I should see
     ) {
         const isExactMatch = (inOrFor === 'for');
 
-        await ccdPage.waitUntilLoaded();
         expect(
             await ccdPage.isFieldValueDisplayed(
                 '',
@@ -171,7 +162,6 @@ Then(/^within the `?(first|second|third|)`?\s?`?([^`]+)`? fieldset, I should see
     ) {
         const isExactMatch = (inOrFor === 'for');
 
-        await ccdPage.waitUntilLoaded();
         expect(
             await ccdPage.isFieldValueDisplayed(
                 fieldLabel,
@@ -193,7 +183,6 @@ Then(/^within the `?(first|second|third|)`?\s?`?([^`]+)`? collection's `?([^\s`]
     ) {
         const isExactMatch = (inOrFor === 'for');
 
-        await ccdPage.waitUntilLoaded();
         expect(
             await ccdPage.isFieldValueDisplayed(
                 '',
@@ -217,7 +206,6 @@ Then(/^within the `?(first|second|third|)`?\s?`?([^`]+)`? collection's `?([^\s`]
     ) {
         const isExactMatch = (inOrFor === 'for');
 
-        await ccdPage.waitUntilLoaded();
         expect(
             await ccdPage.isFieldValueDisplayed(
                 fieldLabel,

--- a/e2e/features/stepDefinitions/ccd-page.steps.ts
+++ b/e2e/features/stepDefinitions/ccd-page.steps.ts
@@ -8,6 +8,7 @@ const ccdPage = new CcdPage();
 Given('I create a new case', async function () {
     await ccdPage.click('Create Case');
     expect(await ccdPage.headingContains('Create Case')).to.equal(true);
+    await ccdPage.isButtonEnabled('Start');
     await ccdPage.click('Start');
 });
 

--- a/e2e/features/stepDefinitions/ccd-page.steps.ts
+++ b/e2e/features/stepDefinitions/ccd-page.steps.ts
@@ -6,7 +6,6 @@ import { expect } from 'chai';
 const ccdPage = new CcdPage();
 
 Given('I create a new case', async function () {
-    // await ccdPage.contentContains('Create Case');
     await ccdPage.linkContains('Create Case');
     await ccdPage.click('Create Case');
     expect(await ccdPage.headingContains('Create Case')).to.equal(true);
@@ -68,7 +67,7 @@ Then(/^the `?([^`]+)`? button is (?:still |)(enabled|disabled)$/, async function
     expect(await ccdPage.isButtonEnabled(buttonText, enabledOrDisabled !== 'enabled')).to.equal(enabledOrDisabled === 'enabled');
 });
 
-When(/^I click the `?([^`]+)`? (button|link|tab|label)$/, async function (linkText, clickyThingy) {
+When(/^I click the `?([^`]+)`? (?:button|link|tab|label)$/, async function (linkText) {
     await ccdPage.click(linkText);
 });
 

--- a/e2e/features/stepDefinitions/ccd-page.steps.ts
+++ b/e2e/features/stepDefinitions/ccd-page.steps.ts
@@ -6,7 +6,7 @@ import { expect } from 'chai';
 const ccdPage = new CcdPage();
 
 Given('I create a new case', async function () {
-    await ccdPage.contentContains('Create Case');
+    // await ccdPage.contentContains('Create Case');
     await ccdPage.linkContains('Create Case');
     await ccdPage.click('Create Case');
     expect(await ccdPage.headingContains('Create Case')).to.equal(true);

--- a/e2e/features/stepDefinitions/ccd-page.steps.ts
+++ b/e2e/features/stepDefinitions/ccd-page.steps.ts
@@ -17,6 +17,14 @@ Given('I create a new case', async function () {
     await ccdPage.click('Start');
 });
 
+Then('I wait for Create Case fields to load', async function () {
+    await ccdPage.headingContains('Create Case');
+    await ccdPage.doesDropdownHaveValues('Jurisdiction');
+    await ccdPage.doesDropdownHaveValues('Case type');
+    await ccdPage.doesDropdownHaveValues('Event');
+    await ccdPage.isButtonEnabled('Start');
+});
+
 Then(/I wait for (\d+) seconds?$/, async function (waitDelay) {
     await browser.sleep(waitDelay * 1000);
 });

--- a/e2e/features/stepDefinitions/ccd-page.steps.ts
+++ b/e2e/features/stepDefinitions/ccd-page.steps.ts
@@ -52,10 +52,6 @@ Then(/^the `?([^`]+)`? button is (?:still |)(enabled|disabled)$/, async function
 });
 
 When(/^I click the `?([^`]+)`? (button|link|tab|label)$/, async function (linkText, clickyThingy) {
-    // console.log("RunningOnAAT = ", RunningOnAAT);
-    // console.log("clickyThingy = ", clickyThingy === 'tab');
-    //
-    // await (RunningOnAAT && clickyThingy === 'tab') ? await browser.sleep(3000) : console.log("NOT waitin bruv!");
     await ccdPage.click(linkText);
 });
 
@@ -64,6 +60,7 @@ Then(/^I should (see|not see) the `?(first|second|third|)`?\s?(?:answer|field) w
         seeOrNotSee,
         instanceNumber
     ) {
+        await ccdPage.waitUntilLoaded();
         expect(await ccdPage.isFieldDisplayed('', instanceNumber)).to.equal(seeOrNotSee === 'see');
     });
 
@@ -73,6 +70,7 @@ Then(/^I should (see|not see) the `?(first|second|third|)`?\s?`?([^`]+)`? (?:ans
         instanceNumber,
         fieldLabel
     ) {
+        await ccdPage.waitUntilLoaded();
         expect(await ccdPage.isFieldDisplayed(fieldLabel, instanceNumber)).to.equal(seeOrNotSee === 'see');
     });
 
@@ -81,6 +79,7 @@ Then(/^the `?(first|second|third|)`?\s?`?([^`]+)`? (?:answer|field) should be em
         instanceNumber,
         fieldLabel
     ) {
+        await ccdPage.waitUntilLoaded();
         expect(await ccdPage.isFieldValueDisplayed(fieldLabel, '', true, instanceNumber)).to.equal(true);
     });
 
@@ -90,6 +89,7 @@ Then(/^the `?(first|second|third|)`?\s?`?([^`]+)`? (?:answer|field) should be (\
         fieldLabel,
         fieldValueSize
     ) {
+        await ccdPage.waitUntilLoaded();
         expect(await ccdPage.isFieldValueCorrectLength(fieldLabel, fieldValueSize, instanceNumber)).to.equal(true);
     });
 
@@ -97,6 +97,7 @@ Then(/^the `?(first|second|third|)`?\s?(?:answer|field) without a label should b
     async function (
         instanceNumber
     ) {
+        await ccdPage.waitUntilLoaded();
         expect(await ccdPage.isFieldValueDisplayed('', '', true, instanceNumber)).to.equal(true);
     });
 
@@ -108,6 +109,7 @@ Then(/^I should see `?([^`]+)`? (in|for) the `?(first|second|third|)`?\s?(?:answ
     ) {
         const isExactMatch = (inOrFor === 'for');
 
+        await ccdPage.waitUntilLoaded();
         expect(
             await ccdPage.isFieldValueDisplayed(
                 '',
@@ -127,6 +129,7 @@ Then(/^I should see `?([^`]+)`? (in|for) the `?(first|second|third|)`?\s?`?([^`]
     ) {
         const isExactMatch = (inOrFor === 'for');
 
+        await ccdPage.waitUntilLoaded();
         expect(
             await ccdPage.isFieldValueDisplayed(
                 fieldLabel,
@@ -146,6 +149,7 @@ Then(/^within the `?(first|second|third|)`?\s?`?([^`]+)`? fieldset, I should see
     ) {
         const isExactMatch = (inOrFor === 'for');
 
+        await ccdPage.waitUntilLoaded();
         expect(
             await ccdPage.isFieldValueDisplayed(
                 '',
@@ -167,6 +171,7 @@ Then(/^within the `?(first|second|third|)`?\s?`?([^`]+)`? fieldset, I should see
     ) {
         const isExactMatch = (inOrFor === 'for');
 
+        await ccdPage.waitUntilLoaded();
         expect(
             await ccdPage.isFieldValueDisplayed(
                 fieldLabel,
@@ -188,6 +193,7 @@ Then(/^within the `?(first|second|third|)`?\s?`?([^`]+)`? collection's `?([^\s`]
     ) {
         const isExactMatch = (inOrFor === 'for');
 
+        await ccdPage.waitUntilLoaded();
         expect(
             await ccdPage.isFieldValueDisplayed(
                 '',
@@ -211,6 +217,7 @@ Then(/^within the `?(first|second|third|)`?\s?`?([^`]+)`? collection's `?([^\s`]
     ) {
         const isExactMatch = (inOrFor === 'for');
 
+        await ccdPage.waitUntilLoaded();
         expect(
             await ccdPage.isFieldValueDisplayed(
                 fieldLabel,

--- a/e2e/features/stepDefinitions/ccd-page.steps.ts
+++ b/e2e/features/stepDefinitions/ccd-page.steps.ts
@@ -37,6 +37,10 @@ Then(/^I (?:am on|should see) the `?([^`]+)`? page$/, async function (headingTex
     expect(await ccdPage.headingContains(headingText)).to.equal(true);
 });
 
+Then(/^I see the open case$/, async function () {
+    expect(await ccdPage.linkContains('Print')).to.equal(true);
+});
+
 Then(/^I should see a notification saying `?([^`]+)`?$/, async function (message) {
     expect(await ccdPage.notificationContains(message)).to.equal(true);
 });

--- a/e2e/features/stepDefinitions/ccd-page.steps.ts
+++ b/e2e/features/stepDefinitions/ccd-page.steps.ts
@@ -6,9 +6,14 @@ import { expect } from 'chai';
 const ccdPage = new CcdPage();
 
 Given('I create a new case', async function () {
+    await ccdPage.contentContains('Create Case');
+    await ccdPage.linkContains('Create Case');
     await ccdPage.click('Create Case');
     expect(await ccdPage.headingContains('Create Case')).to.equal(true);
     await ccdPage.isButtonEnabled('Start');
+    await ccdPage.doesDropdownHaveValues('Jurisdiction');
+    await ccdPage.doesDropdownHaveValues('Case type');
+    await ccdPage.doesDropdownHaveValues('Event');
     await ccdPage.click('Start');
 });
 

--- a/e2e/features/stepDefinitions/ccd-page.steps.ts
+++ b/e2e/features/stepDefinitions/ccd-page.steps.ts
@@ -2,6 +2,7 @@ import { CcdPage } from '../../pages/ccd.page';
 import { Given, Then, When } from 'cucumber';
 import { browser } from 'protractor';
 import { expect } from 'chai';
+// import { RunningOnAAT } from '../../ia.conf';
 
 const ccdPage = new CcdPage();
 
@@ -50,7 +51,11 @@ Then(/^the `?([^`]+)`? button is (?:still |)(enabled|disabled)$/, async function
     expect(await ccdPage.isButtonEnabled(buttonText)).to.equal(enabledOrDisabled === 'enabled');
 });
 
-When(/^I click the `?([^`]+)`? (?:button|link|tab|label)$/, async function (linkText) {
+When(/^I click the `?([^`]+)`? (button|link|tab|label)$/, async function (linkText, clickyThingy) {
+    // console.log("RunningOnAAT = ", RunningOnAAT);
+    // console.log("clickyThingy = ", clickyThingy === 'tab');
+    //
+    // await (RunningOnAAT && clickyThingy === 'tab') ? await browser.sleep(3000) : console.log("NOT waitin bruv!");
     await ccdPage.click(linkText);
 });
 

--- a/e2e/features/stepDefinitions/service/case-list-page.steps.ts
+++ b/e2e/features/stepDefinitions/service/case-list-page.steps.ts
@@ -5,6 +5,10 @@ import { When } from 'cucumber';
 const caseListFlow = new CaseListFlow();
 const ccdPage = new CcdPage();
 
+When(/^I open `?([^`]+)`?$/, async function (uri) {
+    await ccdPage.get(uri);
+});
+
 When('I go to the `Case List`', async function () {
     await ccdPage.get('/list/case');
 });

--- a/e2e/features/stepDefinitions/service/case-list-page.steps.ts
+++ b/e2e/features/stepDefinitions/service/case-list-page.steps.ts
@@ -14,7 +14,7 @@ When('I go to the `Case List`', async function () {
 });
 
 When('I attempt to go to the `Case List`', async function () {
-    await ccdPage.getWithoutWaitingForAngular('/list/case');
+    await ccdPage.get('/list/case');
 });
 
 When('I filter the cases by todays date', async function () {

--- a/e2e/features/stepDefinitions/service/start-appeal.steps.ts
+++ b/e2e/features/stepDefinitions/service/start-appeal.steps.ts
@@ -61,6 +61,11 @@ Given('I complete the `Start appeal check your answers` page', async function ()
     await startAppealFlow.completeCheckYourAnswers(true);
 });
 
+Given(/^I skip the `?([^`]+)`? page by clicking `?([^`]+)`?$/, async function (pageName, buttonName) {
+    expect(await ccdFormPage.headingContains(pageName)).to.equal(true);
+    await ccdFormPage.click(buttonName);
+});
+
 Given('I save my initial appeal', async function () {
     await startAppealFlow.saveAppeal(true);
 });

--- a/e2e/features/stepDefinitions/service/start-appeal.steps.ts
+++ b/e2e/features/stepDefinitions/service/start-appeal.steps.ts
@@ -70,6 +70,10 @@ Given('I save my initial appeal', async function () {
     await startAppealFlow.saveAppeal(true);
 });
 
+Given('I wait for any found addresses to load', async function () {
+    await ccdFormPage.doesDropdownHaveValues('Select an address');
+});
+
 Then(/^I see a list of all nationalities$/, async function () {
 
     const nationalities = await ccdFormPage.getFieldOptions(

--- a/e2e/features/submit-appeal.feature
+++ b/e2e/features/submit-appeal.feature
@@ -20,6 +20,7 @@ Feature: Submit appeal application
     And I should see the text `You will receive an email confirming that this appeal has been submitted successfully.`
     When I click the `Close and Return to case details` button
     Then I should see an alert confirming the case `has been updated with event: Submit your appeal`
+    And I see the open case
 
     When I click the `Case details` tab
     Then the `Reference number` field should be 13 characters long

--- a/e2e/features/submit-case.feature
+++ b/e2e/features/submit-case.feature
@@ -11,7 +11,7 @@ Feature: Submit case
     And I switch to be a `Legal Rep`
     And I build my case
 
-  @create-direction @RIA-517
+  @submit-case @RIA-517
   Scenario: Upload Case argument and evidence
 
     When I select the `Submit your case` Next step

--- a/e2e/features/upload-respondent-evidence.feature
+++ b/e2e/features/upload-respondent-evidence.feature
@@ -30,14 +30,12 @@ Feature: Upload respondent evidence
     When I click the `Close and Return to case details` button
     And I click the `Documents` tab
     Then I should see the `Documents` page
-    And I should see the `Respondent documents` field
     And within the `Respondent documents` collection's first item, I should see `RespondentEvidence.pdf` in the `Document` field
     And within the `Respondent documents` collection's first item, I should see `This is the evidence` in the `Description` field
     And within the `Respondent documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
 
     When I click the `Directions` tab
     Then I should see the `Directions` page
-    And I should see the `Directions` field
     And within the `Directions` collection's first item, I should see `You must now build your case` in the `Explanation` field
     And within the `Directions` collection's first item, I should see `You must write a full argument` in the `Explanation` field
     And within the `Directions` collection's first item, I should see `The respondent then has 14 days to respond` in the `Explanation` field

--- a/e2e/features/upload-respondent-evidence.feature
+++ b/e2e/features/upload-respondent-evidence.feature
@@ -29,13 +29,15 @@ Feature: Upload respondent evidence
 
     When I click the `Close and Return to case details` button
     And I click the `Documents` tab
-    Then I should see the `Respondent documents` field
+    Then I should see the `Documents` page
+    And I should see the `Respondent documents` field
     And within the `Respondent documents` collection's first item, I should see `RespondentEvidence.pdf` in the `Document` field
     And within the `Respondent documents` collection's first item, I should see `This is the evidence` in the `Description` field
     And within the `Respondent documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
 
     When I click the `Directions` tab
-    Then I should see the `Directions` field
+    Then I should see the `Directions` page
+    And I should see the `Directions` field
     And within the `Directions` collection's first item, I should see `You must now build your case` in the `Explanation` field
     And within the `Directions` collection's first item, I should see `You must write a full argument` in the `Explanation` field
     And within the `Directions` collection's first item, I should see `The respondent then has 14 days to respond` in the `Explanation` field

--- a/e2e/fields/fields.ts
+++ b/e2e/fields/fields.ts
@@ -184,6 +184,12 @@ export class Fields {
             ? instanceNumber
             : OrdinalToCardinal.convertWordToNumber(instanceNumber);
 
+        if (complexFieldLabel) {
+            await this.anyPage.contentContains(complexFieldLabel)
+        } else {
+            await this.anyPage.waitUntilLoaded();
+        }
+
         for (let i = 0; i < this.complexFieldFinders.length; i++) {
 
             const complexField =

--- a/e2e/fields/fields.ts
+++ b/e2e/fields/fields.ts
@@ -20,6 +20,7 @@ import { browser, by, ElementFinder, ExpectedConditions } from 'protractor';
 import { CreateCaseFixedListFieldFinder } from './create-case-fixed-list-field-finder';
 import { CcdWriteDocumentFieldFinder } from './ccd-write-document-field-finder';
 import { CcdWriteFixedRadioListFieldFinder } from './ccd-write-fixed-radio-list-field-finder';
+import { AnyPage } from '../pages/any.page';
 
 export class Fields {
 
@@ -63,6 +64,7 @@ export class Fields {
     ];
 
     private readonly container: ElementFinder;
+    private readonly anyPage = new AnyPage();
 
     constructor(container: ElementFinder) {
         this.container = container;
@@ -91,6 +93,16 @@ export class Fields {
     ): Promise<Field> {
 
         let container = this.container;
+
+        if (fieldLabel) {
+            await this.anyPage.contentContains(fieldLabel)
+        } else {
+            await this.anyPage.waitUntilLoaded();
+        }
+
+        if (complexFieldLabel) {
+            await this.anyPage.contentContains(complexFieldLabel)
+        }
 
         if (complexFieldLabel !== undefined) {
 

--- a/e2e/flows/add-appeal-response.flow.ts
+++ b/e2e/flows/add-appeal-response.flow.ts
@@ -9,6 +9,7 @@ export class AddAppealResponseFlow {
         await this.ccdFormPage.selectNextStep('Add appeal response');
         await this.ccdFormPage.click('Go');
 
+        await this.ccdFormPage.headingContains('Add appeal response');
         await this.ccdFormPage.setFieldValue(
             'Response document',
             '{@AppealResponse.pdf}'

--- a/e2e/flows/authentication.flow.ts
+++ b/e2e/flows/authentication.flow.ts
@@ -14,6 +14,7 @@ export class AuthenticationFlow {
             iaConfig.TestCaseOfficerUserName,
             iaConfig.TestCaseOfficerPassword
         );
+        await this.idamSignInPage.contentContains('Case List');
     }
 
     async signInAsJudiciary() {
@@ -23,6 +24,7 @@ export class AuthenticationFlow {
             iaConfig.TestJudiciaryUserName,
             iaConfig.TestJudiciaryPassword
         );
+        await this.idamSignInPage.contentContains('Case List');
     }
 
     async signInAsLawFirmA() {
@@ -32,6 +34,7 @@ export class AuthenticationFlow {
             iaConfig.TestLawFirmAUserName,
             iaConfig.TestLawFirmAPassword
         );
+        await this.idamSignInPage.contentContains('Case List');
     }
 
     async signInAsLawFirmB() {
@@ -41,6 +44,7 @@ export class AuthenticationFlow {
             iaConfig.TestLawFirmBUserName,
             iaConfig.TestLawFirmBPassword
         );
+        await this.idamSignInPage.contentContains('Case List');
     }
 
     async signOut() {
@@ -48,5 +52,6 @@ export class AuthenticationFlow {
         await browser.driver.manage().deleteAllCookies();
         await browser.get(iaConfig.CcdGatewayUrl + '/logout');
         await browser.get(iaConfig.CcdWebUrl + '/');
+        await this.idamSignInPage.waitUntilLoaded();
     }
 }

--- a/e2e/flows/authentication.flow.ts
+++ b/e2e/flows/authentication.flow.ts
@@ -47,6 +47,16 @@ export class AuthenticationFlow {
         await this.idamSignInPage.contentContains('Case List');
     }
 
+    async signInAsLawFirmC() {
+        await this.signOut();
+        await this.idamSignInPage.waitUntilLoaded();
+        await this.idamSignInPage.signIn(
+            iaConfig.TestLawFirmCUserName,
+            iaConfig.TestLawFirmCPassword
+        );
+        await this.idamSignInPage.contentContains('Case List');
+    }
+
     async signOut() {
         await browser.waitForAngularEnabled(false);
         await browser.driver.manage().deleteAllCookies();

--- a/e2e/flows/authentication.flow.ts
+++ b/e2e/flows/authentication.flow.ts
@@ -1,11 +1,13 @@
 import { browser } from 'protractor';
 import { IdamSignInPage } from '../pages/idam-sign-in.page';
+import { AnyPage } from '../pages/any.page';
 
 const iaConfig = require('../ia.conf');
 
 export class AuthenticationFlow {
 
     private idamSignInPage = new IdamSignInPage();
+    private anyPage = new AnyPage();
 
     async signInAsCaseOfficer() {
         await this.signOut();
@@ -14,7 +16,7 @@ export class AuthenticationFlow {
             iaConfig.TestCaseOfficerUserName,
             iaConfig.TestCaseOfficerPassword
         );
-        await this.idamSignInPage.contentContains('Case List');
+        await this.anyPage.contentContains('Case List');
     }
 
     async signInAsJudiciary() {
@@ -24,7 +26,7 @@ export class AuthenticationFlow {
             iaConfig.TestJudiciaryUserName,
             iaConfig.TestJudiciaryPassword
         );
-        await this.idamSignInPage.contentContains('Case List');
+        await this.anyPage.contentContains('Case List');
     }
 
     async signInAsLawFirmA() {
@@ -34,7 +36,7 @@ export class AuthenticationFlow {
             iaConfig.TestLawFirmAUserName,
             iaConfig.TestLawFirmAPassword
         );
-        await this.idamSignInPage.contentContains('Case List');
+        await this.anyPage.contentContains('Case List');
     }
 
     async signInAsLawFirmB() {
@@ -44,7 +46,7 @@ export class AuthenticationFlow {
             iaConfig.TestLawFirmBUserName,
             iaConfig.TestLawFirmBPassword
         );
-        await this.idamSignInPage.contentContains('Case List');
+        await this.anyPage.contentContains('Case List');
     }
 
     async signInAsLawFirmC() {
@@ -54,7 +56,7 @@ export class AuthenticationFlow {
             iaConfig.TestLawFirmCUserName,
             iaConfig.TestLawFirmCPassword
         );
-        await this.idamSignInPage.contentContains('Case List');
+        await this.anyPage.contentContains('Case List');
     }
 
     async signOut() {
@@ -62,6 +64,6 @@ export class AuthenticationFlow {
         await browser.driver.manage().deleteAllCookies();
         await browser.get(iaConfig.CcdGatewayUrl + '/logout');
         await browser.get(iaConfig.CcdWebUrl + '/');
-        await this.idamSignInPage.waitUntilLoaded();
+        await this.anyPage.waitUntilLoaded();
     }
 }

--- a/e2e/flows/build-case.flow.ts
+++ b/e2e/flows/build-case.flow.ts
@@ -9,6 +9,7 @@ export class BuildCaseFlow {
         await this.ccdFormPage.selectNextStep('Build your case');
         await this.ccdFormPage.click('Go');
 
+        await this.ccdFormPage.headingContains('Build your case');
         await this.ccdFormPage.setFieldValue(
             'Appeal skeleton argument',
             '{@CaseArgument.pdf}'
@@ -20,6 +21,7 @@ export class BuildCaseFlow {
         );
 
         await this.ccdFormPage.addCollectionItem('Evidence (Optional)');
+        await this.ccdFormPage.contentContains('Describe the document');
 
         await this.ccdFormPage.setFieldValue(
             'Document (Optional)',

--- a/e2e/flows/case-list.flow.ts
+++ b/e2e/flows/case-list.flow.ts
@@ -6,7 +6,7 @@ export class CaseListFlow {
 
     async filterCasesByTodaysDate(clickApply = false) {
 
-        await this.ccdFormPage.waitUntilLoaded();
+        await this.ccdFormPage.contentContains('Appeal start date');
         await this.ccdFormPage.setFieldValue(
             'Appeal start date',
             '{$TODAY}'
@@ -14,7 +14,7 @@ export class CaseListFlow {
 
         if (clickApply) {
             await this.ccdFormPage.click('Apply');
-            await this.ccdFormPage.waitUntilLoaded();
+            await this.ccdFormPage.contentContains('Status');
         }
     }
 }

--- a/e2e/flows/case-list.flow.ts
+++ b/e2e/flows/case-list.flow.ts
@@ -6,7 +6,6 @@ export class CaseListFlow {
 
     async filterCasesByTodaysDate(clickApply = false) {
 
-        await this.ccdFormPage.contentContains('Appeal start date');
         await this.ccdFormPage.setFieldValue(
             'Appeal start date',
             '{$TODAY}'

--- a/e2e/flows/case-list.flow.ts
+++ b/e2e/flows/case-list.flow.ts
@@ -13,6 +13,7 @@ export class CaseListFlow {
         );
 
         if (clickApply) {
+            await this.ccdFormPage.waitUntilLoaded();
             await this.ccdFormPage.click('Apply');
             await this.ccdFormPage.contentContains('Status');
         }

--- a/e2e/flows/case-list.flow.ts
+++ b/e2e/flows/case-list.flow.ts
@@ -6,6 +6,7 @@ export class CaseListFlow {
 
     async filterCasesByTodaysDate(clickApply = false) {
 
+        await this.ccdFormPage.waitUntilLoaded();
         await this.ccdFormPage.setFieldValue(
             'Appeal start date',
             '{$TODAY}'

--- a/e2e/flows/request-respondent-evidence.flow.ts
+++ b/e2e/flows/request-respondent-evidence.flow.ts
@@ -9,12 +9,15 @@ export class RequestRespondentEvidenceFlow {
         await this.ccdFormPage.selectNextStep('Request respondent evidence');
         await this.ccdFormPage.click('Go');
 
+        await this.ccdFormPage.headingContains('Request respondent evidence');
         await this.ccdFormPage.click('Continue');
+        await this.ccdFormPage.contentContains('Check your answers');
         await this.ccdFormPage.click('Send direction');
+        await this.ccdFormPage.contentContains('You have sent a direction');
 
         if (clickContinue) {
             await this.ccdFormPage.click('Close and Return to case details');
-            await this.ccdFormPage.waitUntilLoaded();
+            await this.ccdFormPage.contentContains('You have sent a direction');
         }
     }
 }

--- a/e2e/flows/request-respondent-review.flow.ts
+++ b/e2e/flows/request-respondent-review.flow.ts
@@ -9,6 +9,7 @@ export class RequestRespondentReviewFlow {
         await this.ccdFormPage.selectNextStep('Request respondent review');
         await this.ccdFormPage.click('Go');
 
+        await this.ccdFormPage.headingContains('Request respondent review');
         await this.ccdFormPage.click('Continue');
         await this.ccdFormPage.click('Send direction');
 

--- a/e2e/flows/start-appeal.flow.ts
+++ b/e2e/flows/start-appeal.flow.ts
@@ -26,7 +26,6 @@ export class StartAppealFlow {
     async completeHomeOfficeReference(clickContinue = false) {
 
         await this.ccdFormPage.headingContains('Home Office reference');
-        await this.ccdFormPage.contentContains('Home Office reference number');
         await this.ccdFormPage.setFieldValue('Home Office reference number', 'A123456/001');
         await this.ccdFormPage.setFieldValue('Date on the decision letter', '31-10-2018');
 
@@ -38,7 +37,6 @@ export class StartAppealFlow {
     async completeBasicDetails(clickContinue = false) {
 
         await this.ccdFormPage.headingContains('Basic details');
-        await this.ccdFormPage.contentContains('Title');
         await this.ccdFormPage.setFieldValue('Title', 'Mr');
         await this.ccdFormPage.setFieldValue('Given names', 'José');
         await this.ccdFormPage.setFieldValue('Family name', 'González');
@@ -54,7 +52,6 @@ export class StartAppealFlow {
     async completeClientAddress(clickContinue = false) {
 
         await this.ccdFormPage.headingContains('Your client\'s address');
-        await this.ccdFormPage.contentContains('Does the appellant have a fixed address?');
         await this.ccdFormPage.setFieldValue('Does the appellant have a fixed address?', 'No');
 
         if (clickContinue) {
@@ -65,7 +62,6 @@ export class StartAppealFlow {
     async whatTypeOfDecisionIsYourClientAppealingAgainst(clickContinue = false) {
 
         await this.ccdFormPage.headingContains('What type of decision');
-        await this.ccdFormPage.contentContains('Decision type');
         await this.ccdFormPage.setFieldValue('Decision type', 'The refusal of a protection claim');
 
         if (clickContinue) {
@@ -76,7 +72,6 @@ export class StartAppealFlow {
     async completeAppealGrounds(clickContinue = false) {
 
         await this.ccdFormPage.headingContains('On which grounds');
-        await this.ccdFormPage.contentContains('Removing the appellant from the UK would breach the UK\'s obligation under the Refugee Convention');
         await this.ccdFormPage.click('Removing the appellant from the UK would breach the UK\'s obligation under the Refugee Convention');
 
         if (clickContinue) {
@@ -87,13 +82,11 @@ export class StartAppealFlow {
     async completeNewMatters(clickContinue = false) {
 
         await this.ccdFormPage.headingContains('New matters');
-        await this.ccdFormPage.contentContains('Are there any new reasons your client wishes to remain in the UK');
         await this.ccdFormPage.setFieldValue(
             'Are there any new reasons your client wishes to remain in the UK ' +
             'or any new grounds on which they should be permitted to stay?',
             'Yes'
         );
-        await this.ccdFormPage.contentContains('Explain what the new matters are and why they are relevant to this appeal');
         await this.ccdFormPage.setFieldValue(
             'Explain what the new matters are and why they are relevant to this appeal.',
             'Birth of a child'
@@ -107,7 +100,6 @@ export class StartAppealFlow {
     async completeOtherAppeals(clickContinue = false) {
 
         await this.ccdFormPage.headingContains('Has your client appealed');
-        await this.ccdFormPage.contentContains('Other appeals');
         await this.ccdFormPage.setFieldValue('Other appeals', 'No');
 
         if (clickContinue) {
@@ -118,7 +110,6 @@ export class StartAppealFlow {
     async completeReferenceNumber(clickContinue = false) {
 
         await this.ccdFormPage.headingContains('Your own reference number');
-        await this.ccdFormPage.contentContains('If you prefer to use your own reference number for this case, you can enter it here');
         await this.ccdFormPage.setFieldValue(
             'If you prefer to use your own reference number for this case, you can enter it here. (Optional)',
             'some-ref'

--- a/e2e/flows/start-appeal.flow.ts
+++ b/e2e/flows/start-appeal.flow.ts
@@ -6,6 +6,7 @@ export class StartAppealFlow {
 
     async completeScreeningQuestions(clickContinue = false) {
 
+        await this.ccdFormPage.contentContains('Tell us about your client');
         await this.ccdFormPage.click('My client is at least 18 years old');
         await this.ccdFormPage.click('My client is not currently in detention');
         await this.ccdFormPage.click('My client isn\'t appealing with other people as part of a linked appeal');
@@ -23,6 +24,7 @@ export class StartAppealFlow {
 
     async completeHomeOfficeReference(clickContinue = false) {
 
+        await this.ccdFormPage.contentContains('Home Office reference');
         await this.ccdFormPage.setFieldValue('Home Office reference number', 'A123456/001');
         await this.ccdFormPage.setFieldValue('Date on the decision letter', '31-10-2018');
 
@@ -33,6 +35,7 @@ export class StartAppealFlow {
 
     async completeBasicDetails(clickContinue = false) {
 
+        await this.ccdFormPage.contentContains('Basic details');
         await this.ccdFormPage.setFieldValue('Title', 'Mr');
         await this.ccdFormPage.setFieldValue('Given names', 'José');
         await this.ccdFormPage.setFieldValue('Family name', 'González');
@@ -47,6 +50,7 @@ export class StartAppealFlow {
 
     async completeClientAddress(clickContinue = false) {
 
+        await this.ccdFormPage.contentContains('Your client\'s address');
         await this.ccdFormPage.setFieldValue('Does the appellant have a fixed address?', 'No');
 
         if (clickContinue) {
@@ -56,6 +60,7 @@ export class StartAppealFlow {
 
     async whatTypeOfDecisionIsYourClientAppealingAgainst(clickContinue = false) {
 
+        await this.ccdFormPage.contentContains('What type of decision');
         await this.ccdFormPage.setFieldValue('Decision type', 'The refusal of a protection claim');
 
         if (clickContinue) {
@@ -65,6 +70,7 @@ export class StartAppealFlow {
 
     async completeAppealGrounds(clickContinue = false) {
 
+        await this.ccdFormPage.contentContains('On which grounds');
         await this.ccdFormPage.click('Removing the appellant from the UK would breach the UK\'s obligation under the Refugee Convention');
 
         if (clickContinue) {
@@ -74,11 +80,13 @@ export class StartAppealFlow {
 
     async completeNewMatters(clickContinue = false) {
 
+        await this.ccdFormPage.contentContains('New matters');
         await this.ccdFormPage.setFieldValue(
             'Are there any new reasons your client wishes to remain in the UK ' +
             'or any new grounds on which they should be permitted to stay?',
             'Yes'
         );
+        await this.ccdFormPage.contentContains('Explain what the new matters are and why they are relevant to this appeal');
         await this.ccdFormPage.setFieldValue(
             'Explain what the new matters are and why they are relevant to this appeal.',
             'Birth of a child'
@@ -91,6 +99,7 @@ export class StartAppealFlow {
 
     async completeOtherAppeals(clickContinue = false) {
 
+        await this.ccdFormPage.contentContains('Has your client appealed');
         await this.ccdFormPage.setFieldValue('Other appeals', 'No');
 
         if (clickContinue) {
@@ -100,6 +109,7 @@ export class StartAppealFlow {
 
     async completeReferenceNumber(clickContinue = false) {
 
+        await this.ccdFormPage.contentContains('Your own reference number');
         await this.ccdFormPage.setFieldValue(
             'If you prefer to use your own reference number for this case, you can enter it here. (Optional)',
             'some-ref'

--- a/e2e/flows/start-appeal.flow.ts
+++ b/e2e/flows/start-appeal.flow.ts
@@ -6,7 +6,8 @@ export class StartAppealFlow {
 
     async completeScreeningQuestions(clickContinue = false) {
 
-        await this.ccdFormPage.contentContains('Tell us about your client');
+        await this.ccdFormPage.headingContains('Tell us about your client');
+        await this.ccdFormPage.contentContains('My client is at least 18 years old');
         await this.ccdFormPage.click('My client is at least 18 years old');
         await this.ccdFormPage.click('My client is not currently in detention');
         await this.ccdFormPage.click('My client isn\'t appealing with other people as part of a linked appeal');
@@ -24,7 +25,8 @@ export class StartAppealFlow {
 
     async completeHomeOfficeReference(clickContinue = false) {
 
-        await this.ccdFormPage.contentContains('Home Office reference');
+        await this.ccdFormPage.headingContains('Home Office reference');
+        await this.ccdFormPage.contentContains('Home Office reference number');
         await this.ccdFormPage.setFieldValue('Home Office reference number', 'A123456/001');
         await this.ccdFormPage.setFieldValue('Date on the decision letter', '31-10-2018');
 
@@ -35,7 +37,8 @@ export class StartAppealFlow {
 
     async completeBasicDetails(clickContinue = false) {
 
-        await this.ccdFormPage.contentContains('Basic details');
+        await this.ccdFormPage.headingContains('Basic details');
+        await this.ccdFormPage.contentContains('Title');
         await this.ccdFormPage.setFieldValue('Title', 'Mr');
         await this.ccdFormPage.setFieldValue('Given names', 'José');
         await this.ccdFormPage.setFieldValue('Family name', 'González');
@@ -50,7 +53,8 @@ export class StartAppealFlow {
 
     async completeClientAddress(clickContinue = false) {
 
-        await this.ccdFormPage.contentContains('Your client\'s address');
+        await this.ccdFormPage.headingContains('Your client\'s address');
+        await this.ccdFormPage.contentContains('Does the appellant have a fixed address?');
         await this.ccdFormPage.setFieldValue('Does the appellant have a fixed address?', 'No');
 
         if (clickContinue) {
@@ -60,7 +64,8 @@ export class StartAppealFlow {
 
     async whatTypeOfDecisionIsYourClientAppealingAgainst(clickContinue = false) {
 
-        await this.ccdFormPage.contentContains('What type of decision');
+        await this.ccdFormPage.headingContains('What type of decision');
+        await this.ccdFormPage.contentContains('Decision type');
         await this.ccdFormPage.setFieldValue('Decision type', 'The refusal of a protection claim');
 
         if (clickContinue) {
@@ -70,7 +75,8 @@ export class StartAppealFlow {
 
     async completeAppealGrounds(clickContinue = false) {
 
-        await this.ccdFormPage.contentContains('On which grounds');
+        await this.ccdFormPage.headingContains('On which grounds');
+        await this.ccdFormPage.contentContains('Removing the appellant from the UK would breach the UK\'s obligation under the Refugee Convention');
         await this.ccdFormPage.click('Removing the appellant from the UK would breach the UK\'s obligation under the Refugee Convention');
 
         if (clickContinue) {
@@ -80,7 +86,8 @@ export class StartAppealFlow {
 
     async completeNewMatters(clickContinue = false) {
 
-        await this.ccdFormPage.contentContains('New matters');
+        await this.ccdFormPage.headingContains('New matters');
+        await this.ccdFormPage.contentContains('Are there any new reasons your client wishes to remain in the UK');
         await this.ccdFormPage.setFieldValue(
             'Are there any new reasons your client wishes to remain in the UK ' +
             'or any new grounds on which they should be permitted to stay?',
@@ -99,7 +106,8 @@ export class StartAppealFlow {
 
     async completeOtherAppeals(clickContinue = false) {
 
-        await this.ccdFormPage.contentContains('Has your client appealed');
+        await this.ccdFormPage.headingContains('Has your client appealed');
+        await this.ccdFormPage.contentContains('Other appeals');
         await this.ccdFormPage.setFieldValue('Other appeals', 'No');
 
         if (clickContinue) {
@@ -109,7 +117,8 @@ export class StartAppealFlow {
 
     async completeReferenceNumber(clickContinue = false) {
 
-        await this.ccdFormPage.contentContains('Your own reference number');
+        await this.ccdFormPage.headingContains('Your own reference number');
+        await this.ccdFormPage.contentContains('If you prefer to use your own reference number for this case, you can enter it here');
         await this.ccdFormPage.setFieldValue(
             'If you prefer to use your own reference number for this case, you can enter it here. (Optional)',
             'some-ref'
@@ -121,6 +130,8 @@ export class StartAppealFlow {
     }
 
     async completeCheckYourAnswers(clickContinue = false) {
+
+        await this.ccdFormPage.headingContains('Check your answers');
 
         if (clickContinue) {
             await this.ccdFormPage.click('Save and continue');

--- a/e2e/flows/submit-case.flow.ts
+++ b/e2e/flows/submit-case.flow.ts
@@ -9,6 +9,7 @@ export class SubmitCaseFlow {
         await this.ccdFormPage.selectNextStep('Submit your case');
         await this.ccdFormPage.click('Go');
 
+        await this.ccdFormPage.headingContains('Submit your case');
         await this.ccdFormPage.click('Submit');
 
         if (clickContinue) {

--- a/e2e/flows/upload-respondent-evidence.flow.ts
+++ b/e2e/flows/upload-respondent-evidence.flow.ts
@@ -9,7 +9,9 @@ export class UploadRespondentEvidenceFlow {
         await this.ccdFormPage.selectNextStep('Upload respondent evidence');
         await this.ccdFormPage.click('Go');
 
+        await this.ccdFormPage.headingContains('Upload respondent evidence');
         await this.ccdFormPage.addCollectionItem('Upload case documents');
+        await this.ccdFormPage.contentContains('Describe the document');
         await this.ccdFormPage.setFieldValue(
             'Document',
             '{@RespondentEvidence.pdf}',

--- a/e2e/ia.conf.js
+++ b/e2e/ia.conf.js
@@ -1,7 +1,7 @@
 module.exports = {
 
   CcdGatewayUrl: process.env.TEST_E2E_URL_GATEWAY || 'https://gateway-ccd.aat.platform.hmcts.net',
-  CcdWebUrl: process.env.TEST_E2E_URL_WEB || 'https://www-ccd.aat.platform.hmcts.net/',
+  CcdWebUrl: process.env.TEST_E2E_URL_WEB || 'https://www-ccd.aat.platform.hmcts.net',
   UseHeadlessBrowser: process.env.TEST_E2E_HEADLESS !== 'false',
   ProxyUrl: process.env.TEST_E2E_URL_PROXY || 'http://proxyout.reform.hmcts.net:8080',
   RunWithNumberOfBrowsers: process.env.TEST_E2E_NUM_BROWSERS || 1,

--- a/e2e/ia.conf.js
+++ b/e2e/ia.conf.js
@@ -1,7 +1,7 @@
 module.exports = {
 
-  CcdGatewayUrl: process.env.TEST_E2E_URL_GATEWAY || 'https://gateway-ccd.nonprod.platform.hmcts.net',
-  CcdWebUrl: process.env.TEST_E2E_URL_WEB || 'https://www-ccd.nonprod.platform.hmcts.net',
+  CcdGatewayUrl: process.env.TEST_E2E_URL_GATEWAY || 'https://gateway-ccd.aat.platform.hmcts.net',
+  CcdWebUrl: process.env.TEST_E2E_URL_WEB || 'https://www-ccd.aat.platform.hmcts.net/',
   UseHeadlessBrowser: process.env.TEST_E2E_HEADLESS !== 'false',
   ProxyUrl: process.env.TEST_E2E_URL_PROXY || 'http://proxyout.reform.hmcts.net:8080',
   RunWithNumberOfBrowsers: process.env.TEST_E2E_NUM_BROWSERS || 1,

--- a/e2e/ia.conf.js
+++ b/e2e/ia.conf.js
@@ -15,6 +15,8 @@ module.exports = {
   TestLawFirmAUserName: process.env.TEST_LAW_FIRM_A_USERNAME,
   TestLawFirmAPassword: process.env.TEST_LAW_FIRM_A_PASSWORD,
   TestLawFirmBUserName: process.env.TEST_LAW_FIRM_B_USERNAME,
-  TestLawFirmBPassword: process.env.TEST_LAW_FIRM_B_PASSWORD
+  TestLawFirmBPassword: process.env.TEST_LAW_FIRM_B_PASSWORD,
+  TestLawFirmCUserName: process.env.TEST_LAW_FIRM_C_USERNAME,
+  TestLawFirmCPassword: process.env.TEST_LAW_FIRM_C_PASSWORD
 
 };

--- a/e2e/ia.conf.js
+++ b/e2e/ia.conf.js
@@ -6,6 +6,7 @@ module.exports = {
   ProxyUrl: process.env.TEST_E2E_URL_PROXY || 'http://proxyout.reform.hmcts.net:8080',
   RunWithNumberOfBrowsers: process.env.TEST_E2E_NUM_BROWSERS || 1,
   UseProxy: process.env.TEST_E2E_USE_PROXY !== 'false',
+  RunningOnAAT: process.env.TEST_RUNNING_ON_AAT || 'true',
 
   TestCaseOfficerUserName: process.env.TEST_CASEOFFICER_USERNAME,
   TestCaseOfficerPassword: process.env.TEST_CASEOFFICER_PASSWORD,

--- a/e2e/pages/any.page.ts
+++ b/e2e/pages/any.page.ts
@@ -229,4 +229,8 @@ export class AnyPage {
             return false;
         }
     }
+
+    async waitUntilLoaded() {
+        await browser.sleep(Wait.minimal);
+    }
 }

--- a/e2e/pages/any.page.ts
+++ b/e2e/pages/any.page.ts
@@ -14,16 +14,6 @@ export class AnyPage {
         await browser.get(uri);
     }
 
-    async getWaitingForAngular(uri: string) {
-        await browser.waitForAngularEnabled(true);
-        await browser.get(uri);
-    }
-
-    async getWithoutWaitingForAngular(uri: string) {
-        await browser.waitForAngularEnabled(false);
-        await browser.get(uri);
-    }
-
     async click(linkText: string) {
 
         const expandedLinkText = await this.valueExpander.expand(linkText);
@@ -140,7 +130,7 @@ export class AnyPage {
                 async () => {
                     return (await element
                         .all(by.xpath(
-                            '//*[self::h1 or self::h2 or self::caption]' +
+                            '//*[self::h1 or self::h2 or self::h3 or self::caption]' +
                             '[contains(normalize-space(), "' + expandedMatch + '") and not(ancestor::*[@hidden])]'
                         ))
                         .filter(e => e.isPresent() && e.isDisplayed())

--- a/e2e/pages/any.page.ts
+++ b/e2e/pages/any.page.ts
@@ -19,12 +19,16 @@ export class AnyPage {
         const expandedLinkText = await this.valueExpander.expand(linkText);
 
         const buttonPath = '//button[normalize-space()="' + expandedLinkText + '"]';
+        const anchorPath = '//a[normalize-space()="' + expandedLinkText + '"]';
+        const linkPath =
+            '//*[self::label or self::span]' +
+            '[text()[normalize-space()="' + expandedLinkText + '"]]';
 
         try {
             await browser.wait(
                 async () => {
                     return (await element
-                        .all(by.xpath(buttonPath))
+                        .all(by.xpath(buttonPath + ' | ' + anchorPath + ' | ' + linkPath))
                         .filter(e => e.isPresent() && e.isDisplayed() && e.isEnabled())
                         .count()) > 0;
                 },
@@ -44,8 +48,6 @@ export class AnyPage {
             return;
         }
 
-        const anchorPath = '//a[normalize-space()="' + expandedLinkText + '"]';
-
         const anchor = await element
             .all(by.xpath(anchorPath))
             .filter(e => e.isPresent() && e.isDisplayed())
@@ -55,10 +57,6 @@ export class AnyPage {
             await anchor.click();
             return;
         }
-
-        const linkPath =
-            '//*[self::label or self::span]' +
-            '[text()[normalize-space()="' + expandedLinkText + '"]]';
 
         const link = await element
             .all(by.xpath(linkPath))

--- a/e2e/pages/any.page.ts
+++ b/e2e/pages/any.page.ts
@@ -92,6 +92,32 @@ export class AnyPage {
         }
     }
 
+    async doesDropdownHaveValues(match: string, shortWait = false) {
+
+        const expandedMatch = await this.valueExpander.expand(match);
+
+        try {
+
+            await browser.wait(
+                async () => {
+                    return (await element
+                        .all(by.xpath(
+                            '//label[contains(normalize-space(),"' + expandedMatch + '")]' +
+                            '/../select/option[string-length(@value) > 0]'
+                        ))
+                        .filter(e => e.isPresent() && e.isDisplayed() && e.isEnabled())
+                        .count()) > 0;
+                },
+                shortWait ? Wait.short : Wait.normal
+            );
+
+            return true;
+
+        } catch (error) {
+            return false;
+        }
+    }
+
     async linkContains(match: string, shortWait = false) {
 
         const expandedMatch = await this.valueExpander.expand(match);

--- a/e2e/pages/any.page.ts
+++ b/e2e/pages/any.page.ts
@@ -82,7 +82,7 @@ export class AnyPage {
                         .filter(e => e.isPresent() && e.isDisplayed() && e.isEnabled())
                         .count()) > 0;
                 },
-                shortWait ? Wait.short : Wait.normal
+                shortWait ? Wait.minimal : Wait.normal
             );
 
             return true;

--- a/e2e/pages/any.page.ts
+++ b/e2e/pages/any.page.ts
@@ -32,7 +32,7 @@ export class AnyPage {
                         .filter(e => e.isPresent() && e.isDisplayed() && e.isEnabled())
                         .count()) > 0;
                 },
-                linkText === 'Close and Return to case details' ? Wait.normal : Wait.minimal
+                linkText === 'Close and Return to case details' ? Wait.normal : Wait.short
             );
         } catch (e) {
             // do nothing and carry on ...

--- a/e2e/pages/any.page.ts
+++ b/e2e/pages/any.page.ts
@@ -11,6 +11,10 @@ export class AnyPage {
     }
 
     async get(uri: string) {
+        await browser.get(uri);
+    }
+
+    async getWaitingForAngular(uri: string) {
         await browser.waitForAngularEnabled(true);
         await browser.get(uri);
     }

--- a/e2e/pages/ccd.page.ts
+++ b/e2e/pages/ccd.page.ts
@@ -125,7 +125,6 @@ export class CcdPage extends AnyPage {
     }
 
     async waitUntilLoaded() {
-        await browser.waitForAngularEnabled(true);
-        await browser.waitForAngular();
+        await browser.sleep(Wait.minimal)
     }
 }

--- a/e2e/pages/ccd.page.ts
+++ b/e2e/pages/ccd.page.ts
@@ -123,8 +123,4 @@ export class CcdPage extends AnyPage {
         return (await browser.driver.getCurrentUrl()).includes('ccd')
             && (await ExpectedConditions.visibilityOf($('#sign-out'))());
     }
-
-    async waitUntilLoaded() {
-        await browser.sleep(Wait.minimal)
-    }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "postinstall": "webdriver-manager update",
     "lint": "tslint -c tslint.json -p tsconfig.json",
     "e2e": "yarn test:fullfunctional",
-    "test:fullfunctional": "protractor ./e2e/features.conf.js",
+    "test:fullfunctional": "protractor ./e2e/features.conf.js --cucumberOpts.format='node_modules/cucumber-pretty'",
     "test:nsp": "nsp check"
   },
   "pre-commit": [
@@ -30,11 +30,11 @@
     "moment": "^2.22.2",
     "nsp": "^3.2.1",
     "pre-commit": "^1.2.2",
-    "protractor": "^5.4.1",
+    "protractor": "^5.4.2",
     "protractor-beautiful-reporter": "^1.2.5",
     "protractor-cucumber-framework": "^6.1.1",
     "protractor-multiple-cucumber-html-reporter-plugin": "^1.8.0",
-    "puppeteer": "^1.11.0",
+    "puppeteer": "^1.12.2",
     "rxjs": "^6.3.3",
     "ts-loader": "^5.2.2",
     "ts-node": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "protractor-beautiful-reporter": "^1.2.5",
     "protractor-cucumber-framework": "^6.1.1",
     "protractor-multiple-cucumber-html-reporter-plugin": "^1.8.0",
-    "puppeteer": "^1.9.0",
+    "puppeteer": "^1.11.0",
     "rxjs": "^6.3.3",
     "ts-loader": "^5.2.2",
     "ts-node": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "chai-as-promised": "^7.1.1",
     "codelyzer": "^4.5.0",
     "cucumber": "^5.0.2",
+    "cucumber-pretty": "^1.5.0",
     "jasmine-core": "^3.2.1",
     "jasmine-spec-reporter": "^4.2.1",
     "moment": "^2.22.2",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "postinstall": "webdriver-manager update",
     "lint": "tslint -c tslint.json -p tsconfig.json",
     "e2e": "yarn test:fullfunctional",
-    "test:fullfunctional": "protractor ./e2e/features.conf.js --cucumberOpts.format='node_modules/cucumber-pretty'",
+    "test:fullfunctional": "protractor ./e2e/features.conf.js --cucumberOpts.tags=~@toggled-off --cucumberOpts.format='node_modules/cucumber-pretty'",
     "test:nsp": "nsp check"
   },
   "pre-commit": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -41,11 +41,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.12.0.tgz#ea6dcbddbc5b584c83f06c60e82736d8fbb0c235"
   integrity sha512-3TUHC3jsBAB7qVRGxT6lWyYo2v96BMmD2PTcl47H25Lu7UXtFH/2qqmKiVrnel6Ne//0TFYf6uvNX+HW2FRkLQ==
 
-"@types/node@^6.0.46":
-  version "6.14.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-6.14.0.tgz#85c6998293fc6f2945915419296c7fbb63384f66"
-  integrity sha512-6tQyh4Q4B5pECcXBOQDZ5KjyBIxRZGzrweGPM47sAYTdVG4+7R+2EGMTmp0h6ZwgqHrFRCeg2gdhsG9xXEl2Sg==
-
 "@types/q@^0.0.32":
   version "0.0.32"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-0.0.32.tgz#bd284e57c84f1325da702babfc82a5328190c0c5"
@@ -2158,12 +2153,11 @@ protractor-multiple-cucumber-html-reporter-plugin@^1.8.0:
     fs-extra "^3.0.1"
     multiple-cucumber-html-reporter "^1.11.0"
 
-protractor@^5.4.1:
-  version "5.4.1"
-  resolved "https://registry.yarnpkg.com/protractor/-/protractor-5.4.1.tgz#011a99e38df7aa45d22455b889ffbb13a6ce0bd9"
-  integrity sha512-ORey5ewQMYiXQxcQohsqEiKYOg/r5yJoJbt0tuROmmgajdg/CA3gTOZNIFJncUVMAJIk5YFqBBLUjKVmQO6tfA==
+protractor@^5.4.2:
+  version "5.4.2"
+  resolved "https://registry.yarnpkg.com/protractor/-/protractor-5.4.2.tgz#329efe37f48b2141ab9467799be2d4d12eb48c13"
+  integrity sha512-zlIj64Cr6IOWP7RwxVeD8O4UskLYPoyIcg0HboWJL9T79F1F0VWtKkGTr/9GN6BKL+/Q/GmM7C9kFVCfDbP5sA==
   dependencies:
-    "@types/node" "^6.0.46"
     "@types/q" "^0.0.32"
     "@types/selenium-webdriver" "^3.0.0"
     blocking-proxy "^1.0.0"
@@ -2205,10 +2199,10 @@ punycode@^1.4.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
-puppeteer@^1.11.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.11.0.tgz#63cdbe12b07275cd6e0b94bce41f3fcb20305770"
-  integrity sha512-iG4iMOHixc2EpzqRV+pv7o3GgmU2dNYEMkvKwSaQO/vMZURakwSOn/EYJ6OIRFYOque1qorzIBvrytPIQB3YzQ==
+puppeteer@^1.12.2:
+  version "1.12.2"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.12.2.tgz#dbc36afc3ba2d7182b1a37523c0081a0e8507c9a"
+  integrity sha512-xWSyCeD6EazGlfnQweMpM+Hs6X6PhUYhNTHKFj/axNZDq4OmrVERf70isBf7HsnFgB3zOC1+23/8+wCAZYg+Pg==
   dependencies:
     debug "^4.1.0"
     extract-zip "^1.6.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -682,6 +682,13 @@ debug@^3.1.0:
   dependencies:
     ms "^2.1.1"
 
+debug@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  dependencies:
+    ms "^2.1.1"
+
 decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -2103,6 +2110,11 @@ progress@^2.0.0:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.1.tgz#c9242169342b1c29d275889c95734621b1952e31"
   integrity sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==
 
+progress@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+
 protractor-beautiful-reporter@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/protractor-beautiful-reporter/-/protractor-beautiful-reporter-1.2.5.tgz#c56194c704828c83e7a72d546f953fa30d3d4711"
@@ -2179,19 +2191,19 @@ punycode@^1.4.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
   integrity sha1-wNWmOycYgArY4esPpSachN1BhF4=
 
-puppeteer@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.9.0.tgz#56dba79e7ea4faac807877bee3b23d63291fc59e"
-  integrity sha512-GH4PmhJf9wBRAPvtJkEJLAvdNNOofZortmBZSj8cGWYni98GUFqsf66blOEfJbo5B8l0KG5HR2d/W2MejnUrzg==
+puppeteer@^1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-1.11.0.tgz#63cdbe12b07275cd6e0b94bce41f3fcb20305770"
+  integrity sha512-iG4iMOHixc2EpzqRV+pv7o3GgmU2dNYEMkvKwSaQO/vMZURakwSOn/EYJ6OIRFYOque1qorzIBvrytPIQB3YzQ==
   dependencies:
-    debug "^3.1.0"
+    debug "^4.1.0"
     extract-zip "^1.6.6"
     https-proxy-agent "^2.2.1"
     mime "^2.0.3"
-    progress "^2.0.0"
+    progress "^2.0.1"
     proxy-from-env "^1.0.0"
     rimraf "^2.6.1"
-    ws "^5.1.1"
+    ws "^6.1.0"
 
 q@1.4.1:
   version "1.4.1"
@@ -3061,10 +3073,10 @@ wreck@^12.5.1:
     boom "5.x.x"
     hoek "4.x.x"
 
-ws@^5.1.1:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
-  integrity sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==
+ws@^6.1.0:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.1.2.tgz#3cc7462e98792f0ac679424148903ded3b9c3ad8"
+  integrity sha512-rfUqzvz0WxmSXtJpPMX2EeASXabOrSMk1ruMOV3JBTBjo4ac2lDjGGsbQSyxj8Odhw5fBib8ZKEjDNvgouNKYw==
   dependencies:
     async-limiter "~1.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -509,6 +509,11 @@ colors@^1.1.2:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.2.tgz#2df8ff573dfbf255af562f8ce7181d6b971a359b"
   integrity sha512-rhP0JSBGYvpcNQj4s5AdShMeE5ahMop96cTeDl/v9qQQm2fYClE2QXZRi8wLzc+GmXSxdIqqbOIAhyObEXDbfQ==
 
+colors@^1.3.2:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.3.3.tgz#39e005d546afe01e01f9c4ca8fa50f686a01205d"
+  integrity sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==
+
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz#2d1d24317afb8abe95d6d2c0b07b57813539d828"
@@ -608,6 +613,15 @@ cucumber-expressions@^6.0.0:
   integrity sha1-R8nFc3gcL/ch161bLNHJf0OZq44=
   dependencies:
     becke-ch--regex--s0-0-v1--base--pl--lib "^1.2.0"
+
+cucumber-pretty@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/cucumber-pretty/-/cucumber-pretty-1.5.0.tgz#2a239ebd06866ee6d3cb6173d24c93012b066e00"
+  integrity sha512-hXkxauUiqxyFCs/Jq19xV/S/WJVaUaoAomINJnO7/QH1tR2RQ+RzWfZppkD6/NlclmHlgg4rEOb2DgG1j7QyGQ==
+  dependencies:
+    cli-table3 "^0.5.1"
+    colors "^1.3.2"
+    figures "^2.0.0"
 
 cucumber-tag-expressions@^1.1.1:
   version "1.1.1"


### PR DESCRIPTION
The CCD UI e2e tests now run as part of the nightly build pipeline, and can be run on demand too. Tests run in parallel by default on 5 shards, but this can be modified if triggering manually.

The main changes are:
- different waits depending on whether the tests are running locally or on AAT
- a lot of additional waits throughout the tests to better handle AAT slowness
- `Jenkinsfile_nightly` changes to pull in vault credentials
- some refactoring of the tests themselves (particularly ones tagged `@migrate-to-unit-tests`) so as not to create so many new cases unnecessarily (much more efficient)