### PR TITLE
Re-introduction of optional angular waiting for better stability when running locally

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -1,9 +1,10 @@
 #!groovy
 
 properties([
-        pipelineTriggers([cron('00 23 * * *')]),
+        pipelineTriggers([cron('30 06 * * *')]),
         parameters([
                 string(name: 'URL_TO_TEST', defaultValue: 'https://www-ccd.aat.platform.hmcts.net', description: 'The URL you want to run these tests against'),
+                string(name: 'CCD_GATEWAY_URL', defaultValue: 'https://gateway-ccd.aat.platform.hmcts.net', description: 'The CCD Gateway URL these tests will need to run'),
                 string(name: 'NUM_TESTS_IN_PARALLEL', defaultValue: '5', description: 'The number of tests to run in parallel')
         ])
 ])
@@ -39,9 +40,10 @@ withNightlyPipeline("nodejs", product, component) {
     loadVaultSecrets(secrets)
 
     env.TEST_E2E_URL_WEB = params.URL_TO_TEST
+    env.TEST_E2E_URL_GATEWAY = params.CCD_GATEWAY_URL
     env.TEST_E2E_NUM_BROWSERS = params.NUM_TESTS_IN_PARALLEL
     enableFullFunctionalTest()
 
-//    enableSlackNotifications('#immigrationandasylum')  // can be turned back on once the overnight functionality is working fully
+    enableSlackNotifications('#ia-tech')
 
 }

--- a/e2e/features/add-appeal-response.feature
+++ b/e2e/features/add-appeal-response.feature
@@ -38,6 +38,7 @@ Feature: Add respondent response
     Then I should see the text `The legal representative will now get an email directing them to review the response.`
 
     When I click the `Close and Return to case details` button
+    And I see the open case
     And I click the `Documents` tab
     Then I should see the `Documents` page
     And within the `Respondent documents` collection's first item, I should see `AppealResponse.pdf` in the `Document` field

--- a/e2e/features/build-case.feature
+++ b/e2e/features/build-case.feature
@@ -36,6 +36,7 @@ Feature: Build case
     Then I should see the text `If you're not yet ready for your case to be reviewed, continue to build your case.`
 
     When I click the `Close and Return to case details` button
+    And I see the open case
     And I click the `Documents` tab
     Then I should see the `Documents` page
     And within the `Legal representative documents` collection's first item, I should see `CaseArgument.pdf` in the `Document` field

--- a/e2e/features/request-respondent-evidence.feature
+++ b/e2e/features/request-respondent-evidence.feature
@@ -32,6 +32,7 @@ Feature: Request respondent evidence
     Then I should see the text `Wait for the respondent to complete the direction`
 
     When I click the `Close and Return to case details` button
+    And I see the open case
     And I click the `Directions` tab
     Then I should see the `Directions` page
     And within the `Directions` collection's first item, I should see `A notice of appeal has been lodged against this asylum decision.` in the `Explanation` field
@@ -59,6 +60,7 @@ Feature: Request respondent evidence
     Then I should see the text `You have sent a direction`
 
     When I click the `Close and Return to case details` button
+    And I see the open case
     And I click the `Directions` tab
     Then I should see the `Directions` page
     And within the `Directions` collection's first item, I should see `Something else` for the `Explanation` field

--- a/e2e/features/request-respondent-review.feature
+++ b/e2e/features/request-respondent-review.feature
@@ -38,6 +38,7 @@ Feature: Request respondent evidence
     Then I should see the text `Wait for the respondent to complete the direction`
 
     When I click the `Close and Return to case details` button
+    And I see the open case
     And I click the `Directions` tab
     Then I should see the `Directions` page
     And within the `Directions` collection's first item, I should see `You must now review this case.` in the `Explanation` field
@@ -65,6 +66,7 @@ Feature: Request respondent evidence
     Then I should see the text `You have sent a direction`
 
     When I click the `Close and Return to case details` button
+    And I see the open case
     And I click the `Directions` tab
     Then I should see the `Directions` page
     And within the `Directions` collection's first item, I should see `Something else` for the `Explanation` field

--- a/e2e/features/upload-respondent-evidence.feature
+++ b/e2e/features/upload-respondent-evidence.feature
@@ -28,6 +28,7 @@ Feature: Upload respondent evidence
     Then I should see the text `The legal representative will now get an email`
 
     When I click the `Close and Return to case details` button
+    And I see the open case
     And I click the `Documents` tab
     Then I should see the `Documents` page
     And within the `Respondent documents` collection's first item, I should see `RespondentEvidence.pdf` in the `Document` field

--- a/e2e/flows/authentication.flow.ts
+++ b/e2e/flows/authentication.flow.ts
@@ -17,6 +17,7 @@ export class AuthenticationFlow {
             iaConfig.TestCaseOfficerPassword
         );
         await this.anyPage.contentContains('Case List');
+        await this.waitForAngularIfNotOnAAT();
     }
 
     async signInAsJudiciary() {
@@ -27,6 +28,7 @@ export class AuthenticationFlow {
             iaConfig.TestJudiciaryPassword
         );
         await this.anyPage.contentContains('Case List');
+        await this.waitForAngularIfNotOnAAT();
     }
 
     async signInAsLawFirmA() {
@@ -37,6 +39,7 @@ export class AuthenticationFlow {
             iaConfig.TestLawFirmAPassword
         );
         await this.anyPage.contentContains('Case List');
+        await this.waitForAngularIfNotOnAAT();
     }
 
     async signInAsLawFirmB() {
@@ -47,6 +50,7 @@ export class AuthenticationFlow {
             iaConfig.TestLawFirmBPassword
         );
         await this.anyPage.contentContains('Case List');
+        await this.waitForAngularIfNotOnAAT();
     }
 
     async signInAsLawFirmC() {
@@ -57,6 +61,7 @@ export class AuthenticationFlow {
             iaConfig.TestLawFirmCPassword
         );
         await this.anyPage.contentContains('Case List');
+        await this.waitForAngularIfNotOnAAT();
     }
 
     async signOut() {
@@ -64,6 +69,12 @@ export class AuthenticationFlow {
         await browser.driver.manage().deleteAllCookies();
         await browser.get(iaConfig.CcdGatewayUrl + '/logout');
         await browser.get(iaConfig.CcdWebUrl + '/');
-        await this.anyPage.waitUntilLoaded();
+        await this.idamSignInPage.waitUntilLoaded();
+    }
+
+    async waitForAngularIfNotOnAAT() {
+        if (!iaConfig.RunningOnAAT) {
+            await browser.waitForAngularEnabled(true);
+        }
     }
 }

--- a/e2e/ia.conf.js
+++ b/e2e/ia.conf.js
@@ -6,7 +6,7 @@ module.exports = {
   ProxyUrl: process.env.TEST_E2E_URL_PROXY || 'http://proxyout.reform.hmcts.net:8080',
   RunWithNumberOfBrowsers: process.env.TEST_E2E_NUM_BROWSERS || 1,
   UseProxy: process.env.TEST_E2E_USE_PROXY !== 'false',
-  RunningOnAAT: process.env.TEST_RUNNING_ON_AAT || 'true',
+  RunningOnAAT: process.env.TEST_RUNNING_ON_AAT !== 'false',
 
   TestCaseOfficerUserName: process.env.TEST_CASEOFFICER_USERNAME,
   TestCaseOfficerPassword: process.env.TEST_CASEOFFICER_PASSWORD,

--- a/e2e/pages/any.page.ts
+++ b/e2e/pages/any.page.ts
@@ -2,6 +2,8 @@ import { browser, by, element } from 'protractor';
 import { Wait } from '../enums/wait';
 import { ValueExpander } from '../helpers/value-expander';
 
+const iaConfig = require('../ia.conf');
+
 export class AnyPage {
 
     protected readonly valueExpander = new ValueExpander();
@@ -255,6 +257,11 @@ export class AnyPage {
     }
 
     async waitUntilLoaded() {
-        await browser.sleep(Wait.minimal);
+        if (iaConfig.RunningOnAAT) {
+            await browser.sleep(Wait.minimal);
+        } else {
+            await browser.waitForAngularEnabled(true);
+            await browser.waitForAngular();
+        }
     }
 }


### PR DESCRIPTION
These changes improve stability and speed when running the e2e tests locally by re-introducing Angular waiting if the `RunningOnAAT` config flag is set to `false`.

This will be backwards compatible with AAT's need for disabled Angular waiting, and has been tested locally with 10 tests in parallel without any failures.