### PR TITLE
Refactor and fix overnight e2e

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -42,6 +42,7 @@ withNightlyPipeline("nodejs", product, component) {
     env.TEST_E2E_URL_WEB = params.URL_TO_TEST
     env.TEST_E2E_URL_GATEWAY = params.CCD_GATEWAY_URL
     env.TEST_E2E_NUM_BROWSERS = params.NUM_TESTS_IN_PARALLEL
+    env.TEST_E2E_WAIT_FOR_ANGULAR = 'false'
     enableFullFunctionalTest()
 
     enableSlackNotifications('#ia-tech')

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -1,7 +1,7 @@
 #!groovy
 
 properties([
-        pipelineTriggers([cron('30 06 * * *')]),
+        pipelineTriggers([cron('00 23 * * *')]),
         parameters([
                 string(name: 'URL_TO_TEST', defaultValue: 'https://www-ccd.aat.platform.hmcts.net', description: 'The URL you want to run these tests against'),
                 string(name: 'CCD_GATEWAY_URL', defaultValue: 'https://gateway-ccd.aat.platform.hmcts.net', description: 'The CCD Gateway URL these tests will need to run'),
@@ -43,6 +43,7 @@ withNightlyPipeline("nodejs", product, component) {
     env.TEST_E2E_URL_GATEWAY = params.CCD_GATEWAY_URL
     env.TEST_E2E_NUM_BROWSERS = params.NUM_TESTS_IN_PARALLEL
     env.TEST_E2E_WAIT_FOR_ANGULAR = 'false'
+    env.TEST_E2E_FAIL_FAST = 'false'
     enableFullFunctionalTest()
 
     enableSlackNotifications('#ia-tech')

--- a/e2e/enums/wait.ts
+++ b/e2e/enums/wait.ts
@@ -1,8 +1,8 @@
 const iaConfig = require('../ia.conf');
 
 export enum Wait {
-    minimal = iaConfig.WaitForAngular ? 3000 : 100,
-    short = iaConfig.WaitForAngular ? 10000 : 1000,
-    normal = iaConfig.WaitForAngular ? 40000 : 10000,
-    long = iaConfig.WaitForAngular ? 120000 : 60000
+    minimal = iaConfig.WaitForAngular ? 100 : 3000,
+    short = iaConfig.WaitForAngular ? 3000 : 10000,
+    normal = iaConfig.WaitForAngular ? 15000 : 40000,
+    long = iaConfig.WaitForAngular ? 30000 : 60000
 }

--- a/e2e/enums/wait.ts
+++ b/e2e/enums/wait.ts
@@ -1,8 +1,8 @@
 const iaConfig = require('../ia.conf');
 
 export enum Wait {
-    minimal = iaConfig.RunningOnAAT ? 3000 : 100,
-    short = iaConfig.RunningOnAAT ? 10000 : 1000,
-    normal = iaConfig.RunningOnAAT ? 40000 : 10000,
-    long = iaConfig.RunningOnAAT ? 120000 : 60000
+    minimal = iaConfig.WaitForAngular ? 3000 : 100,
+    short = iaConfig.WaitForAngular ? 10000 : 1000,
+    normal = iaConfig.WaitForAngular ? 40000 : 10000,
+    long = iaConfig.WaitForAngular ? 120000 : 60000
 }

--- a/e2e/features.conf.js
+++ b/e2e/features.conf.js
@@ -57,7 +57,7 @@ exports.config = {
     keepAlive: false,
     tags: false,
     profile: false,
-    'fail-fast': iaConfig.WaitForAngular,
+    'fail-fast': iaConfig.FailFast,
     'no-source': true
   },
 

--- a/e2e/features.conf.js
+++ b/e2e/features.conf.js
@@ -57,7 +57,7 @@ exports.config = {
     keepAlive: false,
     tags: false,
     profile: false,
-    'fail-fast': !iaConfig.RunningOnAAT,
+    'fail-fast': iaConfig.WaitForAngular,
     'no-source': true
   },
 

--- a/e2e/features/stepDefinitions/authentication.steps.ts
+++ b/e2e/features/stepDefinitions/authentication.steps.ts
@@ -25,10 +25,10 @@ Given(/^I am signed in as(?:| a) `?(?:Solicitor|Legal Rep)(?:| A)`?$/, async fun
 });
 
 Given(/^I am signed in as(?:| a| another) `?(?:Solicitor|Legal Rep)(?:| B)`? without any cases$/, async function () {
-    if (iaConfig.RunningOnAAT) {
-        await authenticationFlow.signInAsLawFirmC();
-    } else {
+    if (iaConfig.WaitForAngular) {
         await authenticationFlow.signInAsLawFirmB();
+    } else {
+        await authenticationFlow.signInAsLawFirmC();
     }
 });
 

--- a/e2e/flows/authentication.flow.ts
+++ b/e2e/flows/authentication.flow.ts
@@ -17,7 +17,7 @@ export class AuthenticationFlow {
             iaConfig.TestCaseOfficerPassword
         );
         await this.anyPage.contentContains('Case List');
-        await this.waitForAngularIfNotOnAAT();
+        await this.waitForAngularIfRequired();
     }
 
     async signInAsJudiciary() {
@@ -28,7 +28,7 @@ export class AuthenticationFlow {
             iaConfig.TestJudiciaryPassword
         );
         await this.anyPage.contentContains('Case List');
-        await this.waitForAngularIfNotOnAAT();
+        await this.waitForAngularIfRequired();
     }
 
     async signInAsLawFirmA() {
@@ -39,7 +39,7 @@ export class AuthenticationFlow {
             iaConfig.TestLawFirmAPassword
         );
         await this.anyPage.contentContains('Case List');
-        await this.waitForAngularIfNotOnAAT();
+        await this.waitForAngularIfRequired();
     }
 
     async signInAsLawFirmB() {
@@ -50,7 +50,7 @@ export class AuthenticationFlow {
             iaConfig.TestLawFirmBPassword
         );
         await this.anyPage.contentContains('Case List');
-        await this.waitForAngularIfNotOnAAT();
+        await this.waitForAngularIfRequired();
     }
 
     async signInAsLawFirmC() {
@@ -61,7 +61,7 @@ export class AuthenticationFlow {
             iaConfig.TestLawFirmCPassword
         );
         await this.anyPage.contentContains('Case List');
-        await this.waitForAngularIfNotOnAAT();
+        await this.waitForAngularIfRequired();
     }
 
     async signOut() {
@@ -72,8 +72,8 @@ export class AuthenticationFlow {
         await this.idamSignInPage.waitUntilLoaded();
     }
 
-    async waitForAngularIfNotOnAAT() {
-        if (!iaConfig.RunningOnAAT) {
+    async waitForAngularIfRequired() {
+        if (iaConfig.WaitForAngular) {
             await browser.waitForAngularEnabled(true);
         }
     }

--- a/e2e/ia.conf.js
+++ b/e2e/ia.conf.js
@@ -7,6 +7,7 @@ module.exports = {
   RunWithNumberOfBrowsers: process.env.TEST_E2E_NUM_BROWSERS || 1,
   UseProxy: process.env.TEST_E2E_USE_PROXY !== 'false',
   WaitForAngular: process.env.TEST_E2E_WAIT_FOR_ANGULAR !== 'false',
+  FailFast: process.env.TEST_E2E_FAIL_FAST !== 'false',
 
   TestCaseOfficerUserName: process.env.TEST_CASEOFFICER_USERNAME,
   TestCaseOfficerPassword: process.env.TEST_CASEOFFICER_PASSWORD,

--- a/e2e/ia.conf.js
+++ b/e2e/ia.conf.js
@@ -6,7 +6,7 @@ module.exports = {
   ProxyUrl: process.env.TEST_E2E_URL_PROXY || 'http://proxyout.reform.hmcts.net:8080',
   RunWithNumberOfBrowsers: process.env.TEST_E2E_NUM_BROWSERS || 1,
   UseProxy: process.env.TEST_E2E_USE_PROXY !== 'false',
-  RunningOnAAT: process.env.TEST_RUNNING_ON_AAT !== 'false',
+  WaitForAngular: process.env.TEST_E2E_WAIT_FOR_ANGULAR !== 'false',
 
   TestCaseOfficerUserName: process.env.TEST_CASEOFFICER_USERNAME,
   TestCaseOfficerPassword: process.env.TEST_CASEOFFICER_PASSWORD,

--- a/e2e/pages/any.page.ts
+++ b/e2e/pages/any.page.ts
@@ -34,7 +34,7 @@ export class AnyPage {
                         .filter(e => e.isPresent() && e.isDisplayed() && e.isEnabled())
                         .count()) > 0;
                 },
-                linkText === 'Close and Return to case details' ? Wait.normal : Wait.short
+                linkText === 'Close and Return to case details' ? Wait.long : Wait.short
             );
         } catch (e) {
             // do nothing and carry on ...

--- a/e2e/pages/any.page.ts
+++ b/e2e/pages/any.page.ts
@@ -257,11 +257,11 @@ export class AnyPage {
     }
 
     async waitUntilLoaded() {
-        if (iaConfig.RunningOnAAT) {
-            await browser.sleep(Wait.minimal);
-        } else {
+        if (iaConfig.WaitForAngular) {
             await browser.waitForAngularEnabled(true);
             await browser.waitForAngular();
+        } else {
+            await browser.sleep(Wait.minimal);
         }
     }
 }


### PR DESCRIPTION
This PR includes a couple of changes:
- fix to put the timeouts in `wait.ts` the right way round
- extend the wait for "Close and Return to case details" button to be more stable in incredibly slow AAT
- refactored `RunningOnAAT` toggle into `WaitForAngular` which is more descriptive (thanks for the suggestion @fantasticjamieburns)
- `FailFast` toggle introduced