### PR TITLE
RIA-2062 Add citizen user

### DIFF
--- a/bin/create-users.sh
+++ b/bin/create-users.sh
@@ -325,3 +325,10 @@ curl --silent -XPUT \
   -H "ServiceAuthorization: Bearer ${SERVICE_TOKEN}" \
   -H "Content-Type: application/json" \
   -d '{"role":"caseworker-ia-respondentofficer","security_classification":"PUBLIC"}'
+
+curl --silent -XPUT \
+  http://localhost:4451/api/user-role \
+  -H "Authorization: Bearer ${USER_TOKEN}" \
+  -H "ServiceAuthorization: Bearer ${SERVICE_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"role":"citizen","security_classification":"PUBLIC"}'


### PR DESCRIPTION
The citizen role is in AAT and prod but not our local docker. It exists in
IDAM but not CCD. Adding the role to the create-users.sh script so we can
start using it for AIP.


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-2062

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
