### PR TITLE
RIA-3542: Support for parallel browser runs when cucumbertags provided.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ $ yarn e2e
 ```bash
 TEST_E2E_NUM_BROWSERS=2 TEST_E2E_HEADLESS=false yarn run localTestParallelScenarios "--cucumberOpts.tags=@share-a-case or @RIA-585"
 
-TEST_E2E_NUM_BROWSERS=2 TEST_E2E_HEADLESS=false yarn run localTestParallelScenarios "--cucumberOpts.tags=@share-a-case or @RIA-585"
+TEST_E2E_NUM_BROWSERS=2 TEST_E2E_HEADLESS=false yarn run localTestParallelFeatures "--cucumberOpts.tags=@share-a-case or @RIA-585"
 ```
 ## Running the tests locally using docker
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ $ yarn install
 $ yarn e2e
  ```
 
+### To run scenarios or features in parallel browser sessions:
+```bash
+TEST_E2E_NUM_BROWSERS=2 TEST_E2E_HEADLESS=false yarn run localTestParallelScenarios "--cucumberOpts.tags=@share-a-case or @RIA-585"
+
+TEST_E2E_NUM_BROWSERS=2 TEST_E2E_HEADLESS=false yarn run localTestParallelScenarios "--cucumberOpts.tags=@share-a-case or @RIA-585"
+```
 ## Running the tests locally using docker
 
 Tests can be executed against an instance of CCD running locally using docker.

--- a/e2e/features.parallel.conf.js
+++ b/e2e/features.parallel.conf.js
@@ -1,0 +1,177 @@
+const _ = require('lodash');
+const glob = require('glob');
+const argv = require('yargs').argv;
+const {
+  PickleFilter,
+  getTestCasesFromFilesystem
+} = require('cucumber');
+const {
+  EventEmitter
+} = require('events');
+const eventBroadcaster = new EventEmitter();
+
+const puppeteer = require('puppeteer');
+const iaConfig = require('./ia.conf');
+const tsNode = require('ts-node');
+const path = require('path');
+
+let capabilities = {
+  browserName: 'chrome',
+  chromeOptions: {
+    args: [
+      '--disable-dev-shm-usage',
+      '--disable-gpu',
+      '--no-sandbox',
+      iaConfig.UseHeadlessBrowser ? '--headless' : '--noop',
+      iaConfig.UseHeadlessBrowser ? '--window-size=1920,1080' : '--noop'
+    ],
+    binary: puppeteer.executablePath()
+  },
+  acceptInsecureCerts: true,
+  maxInstances: iaConfig.RunWithNumberOfBrowsers,
+  proxy: (!iaConfig.UseProxy) ? null : {
+    proxyType: 'manual',
+    httpProxy: iaConfig.ProxyUrl.replace('http://', ''),
+    sslProxy: iaConfig.ProxyUrl.replace('http://', '')
+  },
+  loggingPrefs: {
+    driver: 'INFO',
+    browser: 'INFO'
+  },
+  shardTestFiles: (iaConfig.RunWithNumberOfBrowsers > 1)
+};
+
+class BaseConfig {
+  constructor() {
+    this.baseUrl = iaConfig.CcdWebUrl;
+    this.allScriptsTimeout = 120000;
+    this.getPageTimeout = 120000;
+
+    if (argv.parallelFeatures || argv.parallelScenarios) {
+      this.maxSessions = parseInt(iaConfig.RunWithNumberOfBrowsers, 10);
+      this.getMultiCapabilities = () => {
+        let self = this;
+        return this.getFeaturesByTagExpression().then((results) => {
+          let files;
+          console.log("List of tests to run : " + JSON.stringify(results, null, 2));
+          if (argv.parallelFeatures) {
+            files = results.features;
+          } else {
+            files = results.scenarios;
+          }
+          return _.map(files, function (file, i) {
+            let featureFile = file.replace(/^e2e/, ".");
+            let config = {
+              specs: featureFile,
+              shardTestFiles: true,
+              maxInstances: 1
+            };
+            return _.merge(config, capabilities);
+          });
+        });
+      };
+    } else {
+      this.specs = './features/*.feature';
+      this.capabilities = capabilities;
+    }
+
+    this.disableChecks = true;
+    this.ignoreUncaughtExceptions = true;
+    this.directConnect = true;
+    this.useAllAngular2AppRoots = true;
+
+    // this causes issues with test failing
+    // so do not enable it unless all tests pass
+    // on a variety of environments first :)
+    this.restartBrowserBetweenTests = false;
+
+    this.framework = 'custom';
+    this.frameworkPath = require.resolve('protractor-cucumber-framework');
+
+    this.cucumberOpts = {
+      require: [
+        './cucumber.conf.js',
+        './features/stepDefinitions/**/*.steps.ts'
+      ],
+      keepAlive: false,
+      tags: false,
+      profile: false,
+      'fail-fast': iaConfig.FailFast,
+      'nightly-tag': iaConfig.NightlyTag,
+      'no-source': true
+    };
+
+    this.onPrepare = () => {
+      // returning the promise makes protractor wait for
+      // the reporter config before executing tests
+      global
+        .browser
+        .getProcessedConfig()
+        .then({
+          // noop
+        });
+
+      tsNode.register({
+        project: path.join(__dirname, './tsconfig.e2e.json')
+      });
+    }
+  }
+
+  /*
+   * Returns all feature files that match pattern
+   */
+  getFeatures() {
+    let filesGlob = 'e2e/features/**/*.feature';
+    let files = glob.sync(filesGlob);
+    return _.sortedUniq(files);
+  }
+
+  /*
+   * Use cucumber built in methods
+   * to filter features based on expression
+   */
+  getFeaturesByTagExpression() {
+    return getTestCasesFromFilesystem({
+      cwd: '',
+      eventBroadcaster: eventBroadcaster,
+      featurePaths: this.getFeatures(),
+      pickleFilter: new PickleFilter({
+        tagExpression: this.getCucumberCliTags()
+      }),
+      order: 'defined'
+    }).then(function (results) {
+      let features = [];
+      let scenarios = [];
+      _.forEach(results, function (result) {
+        if (argv.parallelFeatures) {
+          features.push(result.uri);
+        } else {
+          let lineNumber = result.pickle.locations[0].line;
+          let uri = result.uri;
+          let scenario = `${uri}:${lineNumber}`;
+          scenarios.push(scenario);
+        }
+      });
+
+      return {
+        features: _.sortedUniq(features),
+        scenarios: scenarios
+      };
+    });
+  }
+
+  getCucumberCliTags() {
+    let cucumberOptsTags = _.get(argv, 'cucumberOpts.tags');
+    if (typeof cucumberOptsTags === 'string' || cucumberOptsTags instanceof String) {
+      console.log("cucumber opts tags : " + cucumberOptsTags);
+      return cucumberOptsTags;
+    } else {
+      console.log("cucumber opts tags : " + cucumberOptsTags);
+      return cucumberOptsTags.join(" or ") || '';
+    }
+  }
+
+}
+
+
+exports.config = new BaseConfig();

--- a/package.json
+++ b/package.json
@@ -6,8 +6,10 @@
     "postinstall": "webdriver-manager update",
     "lint": "tslint -c tslint.json -p tsconfig.json",
     "e2e": "yarn localTest",
-    "test:fullfunctional": "protractor ./e2e/features.conf.js --cucumberOpts.tags=@nightly-test --cucumberOpts.tags=~@OnlyIfSaveAndContinueIsEnabled --cucumberOpts.format='node_modules/cucumber-pretty'",
+    "test:fullfunctional": "protractor ./e2e/features.parallel.conf.js --parallel-scenarios --cucumberOpts.tags=@nightly-test --cucumberOpts.tags=~@OnlyIfSaveAndContinueIsEnabled --cucumberOpts.format='node_modules/cucumber-pretty'",
     "localTest": "protractor ./e2e/features.conf.js --cucumberOpts.tags=~@toggled-off --cucumberOpts.tags=~@OnlyIfSaveAndContinueIsEnabled --cucumberOpts.format='node_modules/cucumber-pretty'",
+    "localTestParallelScenarios": "protractor ./e2e/features.parallel.conf.js --parallel-scenarios --cucumberOpts.tags=~@toggled-off --cucumberOpts.tags=~@OnlyIfSaveAndContinueIsEnabled --cucumberOpts.format='node_modules/cucumber-pretty'",
+    "localTestParallelFeatures": "protractor ./e2e/features.parallel.conf.js --parallel-features --cucumberOpts.tags=~@toggled-off --cucumberOpts.tags=~@OnlyIfSaveAndContinueIsEnabled --cucumberOpts.format='node_modules/cucumber-pretty'",
     "test:nsp": "nsp check"
   },
   "pre-commit": [


### PR DESCRIPTION
  This change uses getMultiCapabilities instead of capabilities
  configuration of protractor when the options --parallel-scenarios
  or --parallel-features is provided. To control the number of
  browsers, the environment variable 'PARALLEL_BROWSERS_COUNT'
  can be used.

  Examples:
    PARALLEL_BROWSERS_COUNT=2 TEST_E2E_HEADLESS=false yarn e2e --parallel-scenarios --cucumberOpts.tags=@nightly-test
    PARALLEL_BROWSERS_COUNT=2 TEST_E2E_HEADLESS=false yarn e2e --parallel-features --cucumberOpts.tags="@nightly-test or @submit-appeal"

**Before creating a pull request make sure that:**

- [ x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RIA-3542

### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
