### PR TITLE
bulk update for ooc submit hearing requirements

### DIFF
--- a/e2e/features/add-addendum-evidence-admin-officer.feature
+++ b/e2e/features/add-addendum-evidence-admin-officer.feature
@@ -1,22 +1,22 @@
 Feature: Add addendum evidence by Admin Officer
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -69,8 +69,8 @@ Feature: Add addendum evidence by Admin Officer
     And within the `Evidence supplied after the hearing bundle` collection's first item, I should see `some description` for the `Description` field
     And within the `Evidence supplied after the hearing bundle` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
 
-    # Legal Rep
-    When I switch to be a `Legal Rep`
+    # Legal Org User Rep A
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Documents` tab
 
 

--- a/e2e/features/add-addendum-evidence.feature
+++ b/e2e/features/add-addendum-evidence.feature
@@ -2,22 +2,22 @@ Feature: Add addendum evidence
 
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -67,7 +67,7 @@ Feature: Add addendum evidence
     And within the `Evidence supplied after the hearing bundle` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
 
     # LR
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Documents` tab
 
 

--- a/e2e/features/adjourn-without-a-date.feature
+++ b/e2e/features/adjourn-without-a-date.feature
@@ -1,22 +1,22 @@
 Feature: Adjourn hearing without a date
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -66,7 +66,7 @@ Feature: Adjourn hearing without a date
     And I should see the text `When the hearing is ready to be relisted, you must first restore the appeal to its previous state.`
     And I should see `Adjourned` for the `Appointment date and time` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I should only see the `caseOfficer_hearing_adjourned` case progress image
     And I should see the text `Do this next`
     And I should see the text `The hearing has been adjourned and there is no scheduled date for the hearing. You can view the reasons for this in the hearing tab.`

--- a/e2e/features/belfast-hearing-centre.feature
+++ b/e2e/features/belfast-hearing-centre.feature
@@ -2,7 +2,7 @@ Feature: Edit case listing and change the hearing centre to Belfast
 
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
@@ -12,15 +12,15 @@ Feature: Edit case listing and change the hearing centre to Belfast
     And I upload Home Office bundle
     And I switch to be a `Case Officer`
     And I request case building
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`

--- a/e2e/features/case-progression-admin.feature
+++ b/e2e/features/case-progression-admin.feature
@@ -3,7 +3,7 @@ Feature: Case progression - Admin Officer
   @case-progression @case-progression-admin @RIA-1360 @RIA-1939
   Scenario: Case progression information is displayed for each case state for Admin Officer
 
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
@@ -52,7 +52,7 @@ Feature: Case progression - Admin Officer
     And I should see the text `What happens next`
     And I should see the text `The appellant will build their case.`
 
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
 
     When I switch to be a `Admin Officer`
@@ -63,7 +63,7 @@ Feature: Case progression - Admin Officer
     # And I should see the text `What happens next`
     # And I should see the text `The appellant will build their case.`
 
-    # And I switch to be a `Legal Rep`
+    # And I switch to be a `Legal Org User Rep A`
     # And I submit my case
 
     # When I switch to be a `Admin Officer`
@@ -123,8 +123,8 @@ Feature: Case progression - Admin Officer
     And I should see the text `What happens next`
     And I should see the text `The appellant will submit their hearing requirements.`
 
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
 
     When I switch to be a `Admin Officer`
     And I click the `Overview` tab
@@ -217,7 +217,7 @@ Feature: Case progression - Admin Officer
     Then I should only see the `appeal_allowed` case progress image
     And I should see the text `The case has been decided. Either party has the right to appeal this decision, they have 14 days from the date of decision to do this.`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I submit FTPA appeal
 
     When I switch to be a `Admin Officer`

--- a/e2e/features/case-progression-judge.feature
+++ b/e2e/features/case-progression-judge.feature
@@ -3,7 +3,7 @@ Feature: Case progression - Judge
   @case-progression @case-progression-judge @RIA-1360 @RIA-1939
   Scenario: Case progression information is displayed for each case state for Judge
 
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
@@ -52,7 +52,7 @@ Feature: Case progression - Judge
     And I should see the text `What happens next`
     And I should see the text `The appellant will build their case.`
 
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
 
     # Because Save and Continue is false 
@@ -63,7 +63,7 @@ Feature: Case progression - Judge
     # And I should see the text `What happens next`
     # And I should see the text `The appellant will build their case.`
 
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I submit my case
 
     When I switch to be a `Judge`
@@ -123,8 +123,8 @@ Feature: Case progression - Judge
     And I should see the text `What happens next`
     And I should see the text `The appellant will submit their hearing requirements.`
 
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
 
     When I switch to be a `Judge`
     And I click the `Overview` tab
@@ -228,7 +228,7 @@ Feature: Case progression - Judge
     And I should see the text `Do this next`
     And I should see the text `The case has been decided. Either party has the right to appeal this decision, they have 14 days from the date of decision to do this.`
 
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     Then I should only see the `appeal_allowed` case progress image
     And I should see the text `What happens next`

--- a/e2e/features/case-reference-visible-to-admin.feature
+++ b/e2e/features/case-reference-visible-to-admin.feature
@@ -16,7 +16,7 @@ Feature: Remote hearing during Submit hearing requirements
     And I add the appeal response
     And I request hearing requirements
     And I switch to be a `Legal Org User Rep A`
-    And I submit hearing requirements with all yes
+    And I submit hearing requirements with all yes when in country
 
   @RIA-3996 @case-reference-visible-to-admin
   Scenario: Submit hearing requirements with 'Yes' option selected for Remote hearing

--- a/e2e/features/create-case-summary.feature
+++ b/e2e/features/create-case-summary.feature
@@ -3,22 +3,22 @@ Feature: Create case summary
   @regression @case-summary @RIA-364
   Scenario: Case Officer creates case summary
 
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`

--- a/e2e/features/customise-hearing-bundle.feature
+++ b/e2e/features/customise-hearing-bundle.feature
@@ -2,14 +2,14 @@ Feature: Customise hearing bundle
 
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I upload additional evidence
@@ -17,8 +17,8 @@ Feature: Customise hearing bundle
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all no
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all no when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements no path
     And I switch to be a `Admin Officer`
@@ -52,7 +52,7 @@ Feature: Customise hearing bundle
     Then I should see the text `If the bundle fails to generate, you will be notified and need to generate the bundle again.`
 
     And I wait for 10 seconds
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
 
     When I switch to be a `Case Officer`
     And I click the `Documents` tab
@@ -96,7 +96,7 @@ Feature: Customise hearing bundle
     Then I should see the text `If the bundle fails to generate, you will be notified and need to generate the bundle again.`
 
     And I wait for 10 seconds
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
 
     When I switch to be a `Case Officer`
     And I click the `Documents` tab
@@ -137,7 +137,7 @@ Feature: Customise hearing bundle
     Then I should see the text `If the bundle fails to generate, you will be notified and need to generate the bundle again.`
 
     And I wait for 10 seconds
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
 
     When I switch to be a `Case Officer`
     And I click the `Documents` tab

--- a/e2e/features/decision-without-hearing.feature
+++ b/e2e/features/decision-without-hearing.feature
@@ -1,14 +1,14 @@
 Feature: Decision without a hearing from respondent review
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
@@ -40,8 +40,8 @@ Feature: Decision without a hearing from respondent review
   Scenario: Case Officer makes a decision without a hearing from submitHearingRequirements
     When I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Case Officer`
@@ -54,8 +54,8 @@ Feature: Decision without a hearing from respondent review
   Scenario: Case Officer makes a decision without a hearing after adjourned
   When I add the appeal response
   And I request hearing requirements
-  And I switch to be a `Legal Rep`
-  And I submit hearing requirements with all yes
+  And I switch to be a `Legal Org User Rep A`
+  And I submit hearing requirements with all yes when in country
   And I switch to be a `Case Officer`
   And I record agreed hearing requirements yes path
   And I switch to be a `Admin Officer`

--- a/e2e/features/edit-case-listing-after-update-hearing-adjustments.feature
+++ b/e2e/features/edit-case-listing-after-update-hearing-adjustments.feature
@@ -1,22 +1,22 @@
 Feature: Admin Officer - Edit case listing after review update hearing requirements
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`

--- a/e2e/features/edit-case-listing.feature
+++ b/e2e/features/edit-case-listing.feature
@@ -1,22 +1,22 @@
 Feature: Edit case listing
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`

--- a/e2e/features/end-appeal.feature
+++ b/e2e/features/end-appeal.feature
@@ -1,7 +1,7 @@
 Feature: End appeal
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
@@ -50,7 +50,7 @@ Feature: End appeal
     And I should not see the hearing details
     And I should see the case details
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     Then I should only see the `caseOfficer_appealEnded` case progress image
     And I should see the text `Do this next`
@@ -121,7 +121,7 @@ Feature: End appeal
     And I should not see the hearing details
     And I should see the case details
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     Then I should only see the `caseOfficer_appealEnded` case progress image
     And I should see the text `Do this next`
@@ -153,15 +153,15 @@ Feature: End appeal
     And I switch to be a `Case Officer`
     When I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -202,7 +202,7 @@ Feature: End appeal
     And I should see the hearing details
     And I should see the case details
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     Then I should only see the `caseOfficer_appealEnded` case progress image
     And I should see the text `Do this next`
@@ -234,15 +234,15 @@ Feature: End appeal
     And I switch to be a `Case Officer`
     When I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -283,7 +283,7 @@ Feature: End appeal
     And I should see the hearing details
     And I should see the case details
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     Then I should only see the `caseOfficer_appealEnded` case progress image
     And I should see the text `Do this next`

--- a/e2e/features/ftpa-appeal-reheard-ao-list-case-no-path-with-hearing-requirements.feature
+++ b/e2e/features/ftpa-appeal-reheard-ao-list-case-no-path-with-hearing-requirements.feature
@@ -1,22 +1,22 @@
 Feature: Admin Officer lists reheard case with hearing requirements - FTPA reheard decision (resident judge)
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -92,8 +92,8 @@ Feature: Admin Officer lists reheard case with hearing requirements - FTPA rehea
     And I click the `Continue` button
     And I click the `Send direction` button
 
-    When I switch to be a `Legal Rep`
-    And I submit hearing requirements with all no
+    When I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all no when in country
 
     When I switch to be a `Case Officer`
     And I click the `review and submit` link
@@ -215,7 +215,7 @@ Feature: Admin Officer lists reheard case with hearing requirements - FTPA rehea
     And I should see `1 hour` for the `Length` field
     And I should see `{$TODAY+20|D MMM YYYY}, 9:30:00 AM` for the `Date and time` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I should not see the text `These flags are only visible to the Tribunal`
     And I should not see the image `caseFlagSetAsideReheard.svg`
     And I should see the text `Hearing details`

--- a/e2e/features/ftpa-appeal-reheard-ao-list-case-no-path-without-hearing-requirements.feature
+++ b/e2e/features/ftpa-appeal-reheard-ao-list-case-no-path-without-hearing-requirements.feature
@@ -1,22 +1,22 @@
 Feature: Admin Officer lists reheard case without hearing requirements - FTPA reheard decision (resident judge)
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -210,7 +210,7 @@ Feature: Admin Officer lists reheard case without hearing requirements - FTPA re
     And I should see `1 hour` for the `Length` field
     And I should see `{$TODAY+20|D MMM YYYY}, 9:30:00 AM` for the `Date and time` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I should not see the text `These flags are only visible to the Tribunal`
     And I should not see the image `caseFlagSetAsideReheard.svg`
     And I should see the text `Hearing details`

--- a/e2e/features/ftpa-appeal-reheard-ao-list-case-no-path.feature
+++ b/e2e/features/ftpa-appeal-reheard-ao-list-case-no-path.feature
@@ -1,22 +1,22 @@
 Feature: Admin Officer lists reheard case - FTPA reheard decision (resident judge)
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -92,8 +92,8 @@ Feature: Admin Officer lists reheard case - FTPA reheard decision (resident judg
     And I click the `Continue` button
     And I click the `Send direction` button
 
-    When I switch to be a `Legal Rep`
-    And I submit hearing requirements with all no
+    When I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all no when in country
 
     When I switch to be a `Case Officer`
     And I click the `review and submit` link
@@ -215,7 +215,7 @@ Feature: Admin Officer lists reheard case - FTPA reheard decision (resident judg
     And I should see `1 hour` for the `Length` field
     And I should see `{$TODAY+20|D MMM YYYY}, 9:30:00 AM` for the `Date and time` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I should not see the text `These flags are only visible to the Tribunal`
     And I should not see the image `caseFlagSetAsideReheard.svg`
     And I should see the text `Hearing details`

--- a/e2e/features/ftpa-appeal-reheard-ao-list-case-yes-path-with-hearing-requirements.feature
+++ b/e2e/features/ftpa-appeal-reheard-ao-list-case-yes-path-with-hearing-requirements.feature
@@ -1,22 +1,22 @@
 Feature: Admin Officer lists reheard case with hearing requirements - FTPA reheard decision (resident judge)
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all no
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all no when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements no path
     And I switch to be a `Admin Officer`
@@ -92,8 +92,8 @@ Feature: Admin Officer lists reheard case with hearing requirements - FTPA rehea
     And I click the `Continue` button
     And I click the `Send direction` button
 
-    When I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    When I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
 
     When I switch to be a `Case Officer`
     And I click the `review and submit` link
@@ -220,7 +220,7 @@ Feature: Admin Officer lists reheard case with hearing requirements - FTPA rehea
     And I should see `1 hour` for the `Length` field
     And I should see `{$TODAY+20|D MMM YYYY}, 9:30:00 AM` for the `Date and time` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I should not see the text `These flags are only visible to the Tribunal`
     And I should not see the image `caseFlagSetAsideReheard.svg`
     And I should see the text `Hearing details`

--- a/e2e/features/ftpa-appeal-reheard-create-case-summary.feature
+++ b/e2e/features/ftpa-appeal-reheard-create-case-summary.feature
@@ -1,22 +1,22 @@
 Feature: Admin Officer lists reheard case - FTPA reheard decision (resident judge)
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -91,8 +91,8 @@ Feature: Admin Officer lists reheard case - FTPA reheard decision (resident judg
     And I click the `Continue` button
     And I click the `Send direction` button
 
-    When I switch to be a `Legal Rep`
-    And I submit hearing requirements with all no
+    When I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all no when in country
 
     When I switch to be a `Case Officer`
     And I click the `review and submit` link

--- a/e2e/features/ftpa-appeal-reheard-edit-case-listing-with-hearing-requirements.feature
+++ b/e2e/features/ftpa-appeal-reheard-edit-case-listing-with-hearing-requirements.feature
@@ -1,22 +1,22 @@
 Feature: Admin Officer edits case listing - FTPA reheard decision (listed with hearing requirements)
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -62,8 +62,8 @@ Feature: Admin Officer edits case listing - FTPA reheard decision (listed with h
     And I click the `Continue` button
     And I click the `Send direction` button
 
-    When I switch to be a `Legal Rep`
-    Then I submit hearing requirements with all no
+    When I switch to be a `Legal Org User Rep A`
+    Then I submit hearing requirements with all no when in country
 
     When I switch to be a `Case Officer`
     Then I click the `review and submit` link

--- a/e2e/features/ftpa-appeal-reheard-edit-case-listing-without-hearing-requirements.feature
+++ b/e2e/features/ftpa-appeal-reheard-edit-case-listing-without-hearing-requirements.feature
@@ -1,22 +1,22 @@
 Feature: Admin Officer edits case listing - FTPA reheard decision (listed without hearing requirements)
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`

--- a/e2e/features/ftpa-appeal-reheard-edit-document.feature
+++ b/e2e/features/ftpa-appeal-reheard-edit-document.feature
@@ -1,22 +1,22 @@
 Feature: Case Officer edits reheard hearing document - FTPA reheard decision (resident judge)
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -62,8 +62,8 @@ Feature: Case Officer edits reheard hearing document - FTPA reheard decision (re
     And I click the `Continue` button
     And I click the `Send direction` button
 
-    When I switch to be a `Legal Rep`
-    Then I submit hearing requirements with all no
+    When I switch to be a `Legal Org User Rep A`
+    Then I submit hearing requirements with all no when in country
 
     When I switch to be a `Case Officer`
     Then I click the `review and submit` link

--- a/e2e/features/ftpa-appeal-reheard-finalbundling-add-document-to-bundle.feature
+++ b/e2e/features/ftpa-appeal-reheard-finalbundling-add-document-to-bundle.feature
@@ -1,22 +1,22 @@
 Feature: Case Officer add a new document to final bundle for a reheard case
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -113,8 +113,8 @@ Feature: Case Officer add a new document to final bundle for a reheard case
     And I click the `Continue` button
     And I click the `Send direction` button
 
-    When I switch to be a `Legal Rep`
-    And I submit hearing requirements with all no
+    When I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all no when in country
 
     When I switch to be a `Case Officer`
     And I click the `review and submit` link
@@ -201,7 +201,7 @@ Feature: Case Officer add a new document to final bundle for a reheard case
     Then I should see the text `You and the other parties will be notified when the hearing bundle is available.`
     Then I should see the text `If the bundle fails to generate, you will be notified and need to generate the bundle again.`
     And I wait for 10 seconds
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
 
     When I switch to be a `Case Officer`
     And I click the `Documents` tab

--- a/e2e/features/ftpa-appeal-reheard-finalbundling-list-case-no-path.feature
+++ b/e2e/features/ftpa-appeal-reheard-finalbundling-list-case-no-path.feature
@@ -1,22 +1,22 @@
 Feature: Admin Officer lists reheard case - FTPA reheard decision (resident judge)
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all no
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all no when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements no path
     And I switch to be a `Admin Officer`
@@ -115,8 +115,8 @@ Feature: Admin Officer lists reheard case - FTPA reheard decision (resident judg
     And I click the `Continue` button
     And I click the `Send direction` button
 
-    When I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    When I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
 
     When I switch to be a `Case Officer`
     And I click the `review and submit` link
@@ -205,7 +205,7 @@ Feature: Admin Officer lists reheard case - FTPA reheard decision (resident judg
     And I click the `Documents` tab
 
     And I wait for 10 seconds
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
 
     When I switch to be a `Case Officer`
     And I click the `Documents` tab

--- a/e2e/features/ftpa-appeal-reheard-finalbundling-list-case-yes-path.feature
+++ b/e2e/features/ftpa-appeal-reheard-finalbundling-list-case-yes-path.feature
@@ -1,22 +1,22 @@
 Feature: Case Officer create a new hearing bundle for a reheard case
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -88,8 +88,8 @@ Feature: Case Officer create a new hearing bundle for a reheard case
     And I click the `Continue` button
     And I click the `Send direction` button
 
-    When I switch to be a `Legal Rep`
-    And I submit hearing requirements with all no
+    When I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all no when in country
 
     When I switch to be a `Case Officer`
     And I click the `review and submit` link
@@ -168,7 +168,7 @@ Feature: Case Officer create a new hearing bundle for a reheard case
     And I click the `Documents` tab
 
     And I wait for 10 seconds
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
 
     When I switch to be a `Case Officer`
     And I click the `Documents` tab

--- a/e2e/features/ftpa-appeal-reheard-finalbundling-remove-document-to-bundle.feature
+++ b/e2e/features/ftpa-appeal-reheard-finalbundling-remove-document-to-bundle.feature
@@ -1,22 +1,22 @@
 Feature: Case Officer remove document from final bundle for a reheard case
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -113,8 +113,8 @@ Feature: Case Officer remove document from final bundle for a reheard case
     And I click the `Continue` button
     And I click the `Send direction` button
 
-    When I switch to be a `Legal Rep`
-    And I submit hearing requirements with all no
+    When I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all no when in country
 
     When I switch to be a `Case Officer`
     And I click the `review and submit` link
@@ -201,7 +201,7 @@ Feature: Case Officer remove document from final bundle for a reheard case
     Then I should see the text `If the bundle fails to generate, you will be notified and need to generate the bundle again.`
 
     And I wait for 10 seconds
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
 
     When I switch to be a `Case Officer`
     And I click the `Documents` tab

--- a/e2e/features/ftpa-appeal-reheard-new-hearing-requirements.feature
+++ b/e2e/features/ftpa-appeal-reheard-new-hearing-requirements.feature
@@ -1,22 +1,22 @@
 Feature: New hearing requirements for appeal submitted - FTPA reheard decision (resident judge)
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -113,7 +113,7 @@ Feature: New hearing requirements for appeal submitted - FTPA reheard decision (
     And within the `Recordings` collection's first item, I should see `HearingRecording.mp3` for the `Audio file` field
     And within the `Recordings` collection's first item, I should see `some description` for the `Describe the file` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     Then I should only see the `progress_legalRep_submitHearingRequirements` case progress image
     And I should see the text `Do this next`

--- a/e2e/features/ftpa-appeal-reheard-no-hearing-requirements.feature
+++ b/e2e/features/ftpa-appeal-reheard-no-hearing-requirements.feature
@@ -1,22 +1,22 @@
 Feature: Submit without hearing requirements for appeal submitted - FTPA reheard decision (resident judge)
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -109,7 +109,7 @@ Feature: Submit without hearing requirements for appeal submitted - FTPA reheard
     And within the `Previous record of requirements and requests` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
     And I click the `Overview` tab
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     Then I should only see the `progress_legalRep_listing` case progress image
     And I should see the text `What happens next`

--- a/e2e/features/ftpa-appeal-reheard-tcw-review-requirements-no-path.feature
+++ b/e2e/features/ftpa-appeal-reheard-tcw-review-requirements-no-path.feature
@@ -1,22 +1,22 @@
 Feature: Case Officer reviews hearing requirements - FTPA reheard decision (resident judge)
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -92,8 +92,8 @@ Feature: Case Officer reviews hearing requirements - FTPA reheard decision (resi
     And I click the `Continue` button
     And I click the `Send direction` button
 
-    When I switch to be a `Legal Rep`
-    And I submit hearing requirements with all no
+    When I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all no when in country
 
     When I switch to be a `Case Officer`
     Then I should only see the `caseOfficer_listing` case progress image

--- a/e2e/features/ftpa-appeal-reheard-tcw-review-requirements-yes-path.feature
+++ b/e2e/features/ftpa-appeal-reheard-tcw-review-requirements-yes-path.feature
@@ -1,22 +1,22 @@
 Feature: Case Officer reviews hearing requirements - FTPA reheard decision (resident judge)
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all no
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all no when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements no path
     And I switch to be a `Admin Officer`
@@ -92,8 +92,8 @@ Feature: Case Officer reviews hearing requirements - FTPA reheard decision (resi
     And I click the `Continue` button
     And I click the `Send direction` button
 
-    When I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    When I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
 
     When I switch to be a `Case Officer`
     Then I should only see the `caseOfficer_listing` case progress image

--- a/e2e/features/ftpa-appeal-reheard-update-hearing-requirements.feature
+++ b/e2e/features/ftpa-appeal-reheard-update-hearing-requirements.feature
@@ -1,22 +1,22 @@
 Feature: Update hearing requirements for appeal submitted - FTPA reheard decision (resident judge)
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -107,7 +107,7 @@ Feature: Update hearing requirements for appeal submitted - FTPA reheard decisio
     And within the `Previous hearings` collection's first item, I should see `Allowed` for the `Decision of appeal` field
     And within the `Previous hearings` collection's first item, I should see `Decision and reason documents 1` in the `Decision and reason documents` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     Then I should only see the `progress_legalRep_submitHearingRequirements` case progress image
     And I should see the text `Do this next`

--- a/e2e/features/ftpa-appeal-reheard-without-hearing-requirements-no-recordings.feature
+++ b/e2e/features/ftpa-appeal-reheard-without-hearing-requirements-no-recordings.feature
@@ -1,22 +1,22 @@
 Feature: Submit without hearing requirements and no previous hearing recordings for appeal submitted - FTPA reheard decision (resident judge)
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -117,7 +117,7 @@ Feature: Submit without hearing requirements and no previous hearing recordings 
     And I should not see the text `Recordings`
     And I should not see the text `Previous recordings`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     Then I should only see the `progress_legalRep_listing` case progress image
     And I should see the text `What happens next`

--- a/e2e/features/ftpa-appeal-reheard-without-hearing-requirements.feature
+++ b/e2e/features/ftpa-appeal-reheard-without-hearing-requirements.feature
@@ -1,22 +1,22 @@
 Feature: Submit without hearing requirements for appeal submitted - FTPA reheard decision (resident judge)
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -130,7 +130,7 @@ Feature: Submit without hearing requirements for appeal submitted - FTPA reheard
     And within the `Previous recordings` collection's first item, I should see `HearingRecording.mp3` for the `Audio file` field
     And within the `Previous recordings` collection's first item, I should see `some description` for the `Describe the file` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     Then I should only see the `progress_legalRep_listing` case progress image
     And I should see the text `What happens next`

--- a/e2e/features/ftpa-appeal-submitted-overview-tab-respondent-resident-judge.feature
+++ b/e2e/features/ftpa-appeal-submitted-overview-tab-respondent-resident-judge.feature
@@ -1,22 +1,22 @@
 Feature: New overview tab for appeal submitted - FTPA reheard decision (resident judge)
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -90,7 +90,7 @@ Feature: New overview tab for appeal submitted - FTPA reheard decision (resident
     Then I click the `Overview` tab
     And I should not see the option `Request hearing requirements` for the `Next step` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I click the `Overview` tab
     And I should not see the option `Request hearing requirements` for the `Next step` field
 
@@ -207,7 +207,7 @@ Feature: New overview tab for appeal submitted - FTPA reheard decision (resident
     And within the `Directions` collection's first item, I should see `{$TODAY+5|D MMM YYYY} in the `Date due` field
     And within the `Directions` collection's first item, I should see `{$TODAY|D MMM YYYY} in the `Date sent` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I click the `Overview` tab
     And I should see the image `progress_legalRep_submitHearingRequirements.png`
     And I should see the text `Do this next`
@@ -374,7 +374,7 @@ Feature: New overview tab for appeal submitted - FTPA reheard decision (resident
     Then I click the `Overview` tab
     And I should not see the option `Request hearing requirements` for the `Next step` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I click the `Overview` tab
     And I should not see the option `Request hearing requirements` for the `Next step` field
 
@@ -491,7 +491,7 @@ Feature: New overview tab for appeal submitted - FTPA reheard decision (resident
     And within the `Directions` collection's first item, I should see `{$TODAY+5|D MMM YYYY} in the `Date due` field
     And within the `Directions` collection's first item, I should see `{$TODAY|D MMM YYYY} in the `Date sent` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I click the `Overview` tab
     And I should see the image `progress_legalRep_submitHearingRequirements.png`
     And I should see the text `Do this next`

--- a/e2e/features/ftpa-appellant-leadership-judge-decision-and-reasons.feature
+++ b/e2e/features/ftpa-appellant-leadership-judge-decision-and-reasons.feature
@@ -1,22 +1,22 @@
 Feature: Leadership judge record the appellant decision and reasons
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -27,7 +27,7 @@ Feature: Leadership judge record the appellant decision and reasons
     And I start decision and reasons
     And I prepare decision and reasons
     And I send decision and reasons
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I apply for appellant FTPA
 
   @ftpa-appellant-leadership-judge-decision-granted @ftpa-appellant-leadership-judge-decision @RIA-1434 @RIA-2564 @RIA-3211
@@ -138,7 +138,7 @@ Feature: Leadership judge record the appellant decision and reasons
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `FTPA` tab
     And I should see the `FTPA` page
     And I should see `Permission granted` for the `The outcome of the application` field
@@ -517,7 +517,7 @@ Feature: Leadership judge record the appellant decision and reasons
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `FTPA` tab
     And I should see the `FTPA` page
     And I should see the text `Appellant: Decision on permission to appeal`
@@ -920,7 +920,7 @@ Feature: Leadership judge record the appellant decision and reasons
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `FTPA` tab
     And I should see the `FTPA` page
     And I should see the text `Appellant: Decision on permission to appeal`
@@ -1207,7 +1207,7 @@ Feature: Leadership judge record the appellant decision and reasons
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `FTPA` tab
     And I should see the `FTPA` page
     And I should see the text `Appellant: Decision on permission to appeal`

--- a/e2e/features/ftpa-appellant-resident-judge-decision-and-reasons.feature
+++ b/e2e/features/ftpa-appellant-resident-judge-decision-and-reasons.feature
@@ -1,22 +1,22 @@
 Feature: Resident judge record the appellant decision and reasons
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -27,7 +27,7 @@ Feature: Resident judge record the appellant decision and reasons
     And I start decision and reasons
     And I prepare decision and reasons
     And I send decision and reasons
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I apply for appellant FTPA
 
   @ftpa-appellant-resident-judge-decision-granted @ftpa-appellant-resident-judge-decision @RIA-2527 @RIA-2571 @RIA-3211
@@ -144,7 +144,7 @@ Feature: Resident judge record the appellant decision and reasons
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `FTPA` tab
     And I should see the `FTPA` page
     And I should see `Permission granted` for the `The outcome of the application` field
@@ -509,7 +509,7 @@ Feature: Resident judge record the appellant decision and reasons
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `FTPA` tab
     And I should see the `FTPA` page
     And I should see `Permission partially granted` for the `The outcome of the application` field
@@ -776,7 +776,7 @@ Feature: Resident judge record the appellant decision and reasons
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `FTPA` tab
     And I should see the `FTPA` page
     And I should see `Permission refused` for the `The outcome of the application` field
@@ -1042,7 +1042,7 @@ Feature: Resident judge record the appellant decision and reasons
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `FTPA` tab
     And I should see the `FTPA` page
     And I should see `Decision set aside and to be reheard in the First-tier under rule 35` for the `The outcome of the application` field
@@ -1318,7 +1318,7 @@ Feature: Resident judge record the appellant decision and reasons
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `FTPA` tab
     And I should see the `FTPA` page
     And I should see `Decision set aside and to be reheard in the First-tier under rule 32` for the `The outcome of the application` field
@@ -1571,7 +1571,7 @@ Feature: Resident judge record the appellant decision and reasons
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `FTPA` tab
     And I should see the `FTPA` page
     And I should see `Decision set aside and remade in the First-tier under rule 32` for the `The outcome of the application` field

--- a/e2e/features/ftpa-appellant.feature
+++ b/e2e/features/ftpa-appellant.feature
@@ -2,22 +2,22 @@ Feature: FTPA Appellant application to the Upper Tribunal
 
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -32,7 +32,7 @@ Feature: FTPA Appellant application to the Upper Tribunal
 
   @ftpa-appellant @RIA-1293 @RIA-2581
   Scenario: FTPA Appellant application
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
     And I should see the text `What happens next`

--- a/e2e/features/ftpa-decided-overview-tab-respondent-resident-judge.feature
+++ b/e2e/features/ftpa-decided-overview-tab-respondent-resident-judge.feature
@@ -1,22 +1,22 @@
 Feature: New Overview tab - FTPA resident judge records the appellant decision and reasons
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -114,7 +114,7 @@ Feature: New Overview tab - FTPA resident judge records the appellant decision a
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
     And I should see the text `What happens next`
@@ -255,7 +255,7 @@ Feature: New Overview tab - FTPA resident judge records the appellant decision a
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
     And I should see the text `What happens next`

--- a/e2e/features/ftpa-decided-remove-ftpa-flag-from-case.feature
+++ b/e2e/features/ftpa-decided-remove-ftpa-flag-from-case.feature
@@ -1,22 +1,22 @@
 Feature: Remove Set aside - Reheard flag from a reheard case at FTPA decided state
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`

--- a/e2e/features/ftpa-decision-to-decided.feature
+++ b/e2e/features/ftpa-decision-to-decided.feature
@@ -1,22 +1,22 @@
 Feature: TCW progresses case from decision to decided - FTPA reheard decision (resident judge)
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -89,8 +89,8 @@ Feature: TCW progresses case from decision to decided - FTPA reheard decision (r
     And I click the `Continue` button
     And I click the `Send direction` button
 
-    When I switch to be a `Legal Rep`
-    And I submit hearing requirements with all no
+    When I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all no when in country
 
     When I switch to be a `Case Officer`
     Then I click the `review and submit` link
@@ -192,7 +192,7 @@ Feature: TCW progresses case from decision to decided - FTPA reheard decision (r
     And within the `Decision and reason documents` collection's second item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
     And I click the `Overview` tab
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I should only see the `appeal_allowed` case progress image
     And I should see the text `What happens next`
     And I should see the text `The appeal has been decided. You have the right to apply for permission to appeal to the Upper Tribunal.`

--- a/e2e/features/ftpa-display-final-decision-scenario-1.feature
+++ b/e2e/features/ftpa-display-final-decision-scenario-1.feature
@@ -1,22 +1,22 @@
 Feature: Final display for FTPA decision and reasons
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -35,7 +35,7 @@ Feature: Final display for FTPA decision and reasons
     #  Granted / Granted (Final Decision: Granted - Scenario 1)
   Scenario: FTPA judge decision - Granted
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a `Judge`
@@ -59,7 +59,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 
@@ -113,7 +113,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 

--- a/e2e/features/ftpa-display-final-decision-scenario-10.feature
+++ b/e2e/features/ftpa-display-final-decision-scenario-10.feature
@@ -1,22 +1,22 @@
 Feature: Final display for FTPA decision and reasons
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -33,7 +33,7 @@ Feature: Final display for FTPA decision and reasons
     #  Reheard Rule 32 / Reheard Rule 35 (Final Decision: Reheard Rule 35 - Scenario 10)
   Scenario: FTPA judge decision - Reheard
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -56,7 +56,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 
@@ -107,7 +107,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 
@@ -136,7 +136,7 @@ Feature: Final display for FTPA decision and reasons
     #  Reheard Rule 35 / Reheard Rule 32 (Final Decision: Reheard Rule 32 - Scenario 10)
   Scenario: FTPA judge decision - Reheard
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -163,7 +163,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 
@@ -209,7 +209,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 

--- a/e2e/features/ftpa-display-final-decision-scenario-11.feature
+++ b/e2e/features/ftpa-display-final-decision-scenario-11.feature
@@ -1,22 +1,22 @@
 Feature: Final display for FTPA decision and reasons
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -34,7 +34,7 @@ Feature: Final display for FTPA decision and reasons
 
     And I send decision and reasons
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -56,7 +56,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
 
@@ -106,7 +106,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `appeal_allowed.png`
     And I should not see the image `appeal_dismissed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
     And I should not see the image `appeal_dismissed.png`
@@ -143,7 +143,7 @@ Feature: Final display for FTPA decision and reasons
 
     And I send decision and reasons with dismissed outcome
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -165,7 +165,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
 
@@ -215,7 +215,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `appeal_allowed.png`
     And I should not see the image `appeal_dismissed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
     And I should not see the image `appeal_dismissed.png`
@@ -252,7 +252,7 @@ Feature: Final display for FTPA decision and reasons
 
     And I send decision and reasons
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -274,7 +274,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
 
@@ -324,7 +324,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `appeal_dismissed.png`
     And I should not see the image `appeal_allowed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
     And I should not see the image `appeal_allowed.png`
@@ -361,7 +361,7 @@ Feature: Final display for FTPA decision and reasons
 
     And I send decision and reasons with dismissed outcome
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -383,7 +383,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
 
@@ -433,7 +433,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `appeal_dismissed.png`
     And I should not see the image `appeal_allowed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
     And I should not see the image `appeal_allowed.png`
@@ -470,7 +470,7 @@ Feature: Final display for FTPA decision and reasons
 
     And I send decision and reasons
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -492,7 +492,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
 
@@ -537,7 +537,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `appeal_allowed.png`
     And I should not see the image `appeal_dismissed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
     And I should not see the image `appeal_dismissed.png`
@@ -574,7 +574,7 @@ Feature: Final display for FTPA decision and reasons
 
     And I send decision and reasons
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -596,7 +596,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
 
@@ -641,7 +641,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `appeal_dismissed.png`
     And I should not see the image `appeal_allowed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
     And I should not see the image `appeal_allowed.png`
@@ -678,7 +678,7 @@ Feature: Final display for FTPA decision and reasons
 
     And I send decision and reasons
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -698,7 +698,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
 
@@ -745,7 +745,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `appeal_allowed.png`
     And I should not see the image `appeal_dismissed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
     And I should not see the image `appeal_dismissed.png`
@@ -782,7 +782,7 @@ Feature: Final display for FTPA decision and reasons
 
     And I send decision and reasons
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -802,7 +802,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
 
@@ -849,7 +849,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `appeal_dismissed.png`
     And I should not see the image `appeal_allowed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
     And I should not see the image `appeal_allowed.png`
@@ -886,7 +886,7 @@ Feature: Final display for FTPA decision and reasons
 
     And I send decision and reasons
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -907,7 +907,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
 
@@ -954,7 +954,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `appeal_allowed.png`
     And I should not see the image `appeal_dismissed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
     And I should not see the image `appeal_dismissed.png`
@@ -991,7 +991,7 @@ Feature: Final display for FTPA decision and reasons
 
     And I send decision and reasons
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -1012,7 +1012,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
 
@@ -1059,7 +1059,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `appeal_dismissed.png`
     And I should not see the image `appeal_allowed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
     And I should not see the image `appeal_allowed.png`

--- a/e2e/features/ftpa-display-final-decision-scenario-12.feature
+++ b/e2e/features/ftpa-display-final-decision-scenario-12.feature
@@ -1,22 +1,22 @@
 Feature: Final display for FTPA decision and reasons
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -34,7 +34,7 @@ Feature: Final display for FTPA decision and reasons
     #  Remade Rule 32 / Reheard Rule 35 (Final Decision: Reheard Rule 35 - Scenario 12)
   Scenario: FTPA appellant leadership judge decision - Reheard Rule 35
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -56,7 +56,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
 
@@ -108,7 +108,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `appeal_reheard.png`
     And I should not see the image `appeal_allowed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
     And I should not see the image `appeal_allowed.png`
@@ -143,7 +143,7 @@ Feature: Final display for FTPA decision and reasons
     #  Remade Rule 32 / Reheard Rule 32 (Final Decision: Reheard Rule 32 - Scenario 12)
   Scenario: FTPA judge decision - Reheard Rule 35
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -165,7 +165,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
 
@@ -212,7 +212,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `appeal_reheard.png`
     And I should not see the image `appeal_allowed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
     And I should not see the image `appeal_allowed.png`

--- a/e2e/features/ftpa-display-final-decision-scenario-13.feature
+++ b/e2e/features/ftpa-display-final-decision-scenario-13.feature
@@ -2,22 +2,22 @@ Feature: Final display for FTPA decision and reasons
 
   Background:
 
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -35,7 +35,7 @@ Feature: Final display for FTPA decision and reasons
 
     And I send decision and reasons
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -58,7 +58,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 
@@ -105,7 +105,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `appeal_allowed.png`
     And I should not see the image `appeal_reheard.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
     And I should not see the image `appeal_reheard.png`
@@ -142,7 +142,7 @@ Feature: Final display for FTPA decision and reasons
 
     And I send decision and reasons with dismissed outcome
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -165,7 +165,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 
@@ -212,7 +212,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `appeal_dismissed.png`
     And I should not see the image `appeal_reheard.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
     And I should not see the image `appeal_reheard.png`
@@ -249,7 +249,7 @@ Feature: Final display for FTPA decision and reasons
 
     And I send decision and reasons
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -276,7 +276,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 
@@ -323,7 +323,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `appeal_allowed.png`
     And I should not see the image `appeal_reheard.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
     And I should not see the image `appeal_reheard.png`
@@ -360,7 +360,7 @@ Feature: Final display for FTPA decision and reasons
 
     And I send decision and reasons with dismissed outcome
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -387,7 +387,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 
@@ -434,7 +434,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `appeal_dismissed.png`
     And I should not see the image `appeal_reheard.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
     And I should not see the image `appeal_reheard.png`

--- a/e2e/features/ftpa-display-final-decision-scenario-14.feature
+++ b/e2e/features/ftpa-display-final-decision-scenario-14.feature
@@ -1,22 +1,22 @@
 Feature: Final display for FTPA decision and reasons
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -33,7 +33,7 @@ Feature: Final display for FTPA decision and reasons
     #  Remade Rule 32 (Allowed) / Remade Rule 32 (Allowed) (Final Decision: Remade Rule 32 - Scenario 14)
   Scenario: FTPA judge decision - Remade Rule 32 (Allowed)
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -55,7 +55,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
 
@@ -101,7 +101,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
 
@@ -130,7 +130,7 @@ Feature: Final display for FTPA decision and reasons
     #  Remade Rule 32 (Allowed) / Remade Rule 32 (Dismissed) (Final Decision: Remade Rule 32 - Scenario 14)
   Scenario: FTPA judge decision - Remade Rule 32 (Dismissed)
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -152,7 +152,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
 
@@ -199,7 +199,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `appeal_dismissed.png`
     And I should not see the image `appeal_allowed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
     And I should not see the image `appeal_allowed.png`
@@ -234,7 +234,7 @@ Feature: Final display for FTPA decision and reasons
     #  Remade Rule 32 (Dismissed) / Remade Rule 32 (Dismissed) (Final Decision: Remade Rule 32 - Scenario 14)
   Scenario: FTPA judge decision - Remade Rule 32 (Dismissed)
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -256,7 +256,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
 
@@ -303,7 +303,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `appeal_dismissed.png`
     And I should not see the image `appeal_allowed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
     And I should not see the image `appeal_allowed.png`
@@ -338,7 +338,7 @@ Feature: Final display for FTPA decision and reasons
     #  Remade Rule 32 (Dismissed) / Remade Rule 32 (Allowed) (Final Decision: Remade Rule 32 - Scenario 14)
   Scenario: FTPA judge decision - Remade Rule 32 (Allowed)
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -360,7 +360,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
 
@@ -407,7 +407,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `appeal_allowed.png`
     And I should not see the image `appeal_dismissed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
     And I should not see the image `appeal_dismissed.png`

--- a/e2e/features/ftpa-display-final-decision-scenario-2.feature
+++ b/e2e/features/ftpa-display-final-decision-scenario-2.feature
@@ -1,22 +1,22 @@
 Feature: Final display for FTPA decision and reasons
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -63,7 +63,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 
@@ -87,7 +87,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -110,7 +110,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 

--- a/e2e/features/ftpa-display-final-decision-scenario-3.feature
+++ b/e2e/features/ftpa-display-final-decision-scenario-3.feature
@@ -1,22 +1,22 @@
 Feature: Final display for FTPA decision and reasons
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -33,7 +33,7 @@ Feature: Final display for FTPA decision and reasons
     #  Granted / Partially Granted (Final Decision: Granted - Scenario 3)
   Scenario: FTPA judge decision - Granted
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -57,7 +57,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 
@@ -112,7 +112,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `ftpaGranted.png`
     And I should not see the image `ftpaGrantedPartiallyGranted.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 
@@ -141,7 +141,7 @@ Feature: Final display for FTPA decision and reasons
     #  Partially Granted / Granted (Final Decision: Granted - Scenario 3)
   Scenario: FTPA judge decision - Granted
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -165,7 +165,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 
@@ -220,7 +220,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `ftpaGranted.png`
     And I should not see the image `ftpaGrantedPartiallyGranted.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 

--- a/e2e/features/ftpa-display-final-decision-scenario-4.feature
+++ b/e2e/features/ftpa-display-final-decision-scenario-4.feature
@@ -1,22 +1,22 @@
 Feature: Final display for FTPA decision and reasons
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -33,7 +33,7 @@ Feature: Final display for FTPA decision and reasons
     #  Granted / Refused (Final Decision: Granted - Scenario 4a)
   Scenario: FTPA judge decision - Granted
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -57,7 +57,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 
@@ -107,7 +107,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_dismissed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_dismissed.png`
@@ -142,7 +142,7 @@ Feature: Final display for FTPA decision and reasons
     #  Not Admitted / Granted (Final Decision: Granted - Scenario 4a)
   Scenario: FTPA judge decision - Granted
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -162,7 +162,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
 
@@ -217,7 +217,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_dismissed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_dismissed.png`
@@ -252,7 +252,7 @@ Feature: Final display for FTPA decision and reasons
     #  Partially Granted / Refused (Final Decision: Granted - Scenario 4b)
   Scenario: FTPA judge decision - Granted
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -276,7 +276,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 
@@ -326,7 +326,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_dismissed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_dismissed.png`
@@ -361,7 +361,7 @@ Feature: Final display for FTPA decision and reasons
     #  Not Admitted / Partially Granted (Final Decision: Granted - Scenario 4b)
   Scenario: FTPA judge decision - Granted
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -381,7 +381,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
 
@@ -436,7 +436,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_dismissed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_dismissed.png`

--- a/e2e/features/ftpa-display-final-decision-scenario-5.feature
+++ b/e2e/features/ftpa-display-final-decision-scenario-5.feature
@@ -2,22 +2,22 @@ Feature: Final display for FTPA decision and reasons
 
   Background:
 
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -35,7 +35,7 @@ Feature: Final display for FTPA decision and reasons
 
     And I send decision and reasons
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -56,7 +56,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
 
@@ -106,7 +106,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `appeal_allowed.png`
     And I should not see the image `appeal_dismissed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
     And I should not see the image `appeal_dismissed.png`
@@ -143,7 +143,7 @@ Feature: Final display for FTPA decision and reasons
 
     And I send decision and reasons with dismissed outcome
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -164,7 +164,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
 
@@ -214,7 +214,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `appeal_dismissed.png`
     And I should not see the image `appeal_allowed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
     And I should not see the image `appeal_allowed.png`

--- a/e2e/features/ftpa-display-final-decision-scenario-6.feature
+++ b/e2e/features/ftpa-display-final-decision-scenario-6.feature
@@ -1,22 +1,22 @@
 Feature: Final display for FTPA decision and reasons
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -34,7 +34,7 @@ Feature: Final display for FTPA decision and reasons
 
     And I send decision and reasons
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -54,7 +54,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
 
@@ -99,7 +99,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `appeal_allowed.png`
     And I should not see the image `appeal_dismissed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
     And I should not see the image `appeal_dismissed.png`
@@ -136,7 +136,7 @@ Feature: Final display for FTPA decision and reasons
 
     And I send decision and reasons with dismissed outcome
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -156,7 +156,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
 
@@ -201,7 +201,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `appeal_dismissed.png`
     And I should not see the image `appeal_allowed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_dismissed.png`
     And I should not see the image `appeal_allowed.png`

--- a/e2e/features/ftpa-display-final-decision-scenario-7.feature
+++ b/e2e/features/ftpa-display-final-decision-scenario-7.feature
@@ -1,22 +1,22 @@
 Feature: Final display for FTPA decision and reasons
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -33,7 +33,7 @@ Feature: Final display for FTPA decision and reasons
     #  Granted / Reheard Rule 35 (Final Decision: Granted - Scenario 7)
   Scenario: FTPA judge decision - Granted
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -57,7 +57,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 
@@ -109,7 +109,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_reheard.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_reheard.png`
@@ -144,7 +144,7 @@ Feature: Final display for FTPA decision and reasons
     #  Granted / Reheard Rule 32 (Final Decision: Granted - Scenario 7)
   Scenario: FTPA judge decision - Granted
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -168,7 +168,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 
@@ -215,7 +215,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_reheard.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_reheard.png`
@@ -250,7 +250,7 @@ Feature: Final display for FTPA decision and reasons
     #  Granted / Remade Rule 32 (Final Decision: Granted - Scenario 7)
   Scenario: FTPA judge decision - Granted
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -274,7 +274,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 
@@ -321,7 +321,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_reheard.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_allowed.png`
@@ -356,7 +356,7 @@ Feature: Final display for FTPA decision and reasons
     #  Reheard Rule 35 / Granted (Final Decision: Granted - Scenario 7)
   Scenario: FTPA judge decision - Granted
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -383,7 +383,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 
@@ -438,7 +438,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_reheard.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_reheard.png`
@@ -473,7 +473,7 @@ Feature: Final display for FTPA decision and reasons
     #  Reheard Rule 32 / Granted (Final Decision: Granted - Scenario 7)
   Scenario: FTPA judge decision - Granted
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -496,7 +496,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 
@@ -551,7 +551,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_reheard.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_reheard.png`
@@ -586,7 +586,7 @@ Feature: Final display for FTPA decision and reasons
     #  Remade Rule 32 / Granted (Final Decision: Granted - Scenario 7)
   Scenario: FTPA judge decision - Granted
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -608,7 +608,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
 
@@ -663,7 +663,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_allowed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_allowed.png`

--- a/e2e/features/ftpa-display-final-decision-scenario-8.feature
+++ b/e2e/features/ftpa-display-final-decision-scenario-8.feature
@@ -1,22 +1,22 @@
 Feature: Final display for FTPA decision and reasons
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -33,7 +33,7 @@ Feature: Final display for FTPA decision and reasons
     #  Partially Granted / Reheard Rule 35 (Final Decision: Granted - Scenario 8)
   Scenario: FTPA judge decision - Granted
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -57,7 +57,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 
@@ -109,7 +109,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_reheard.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_reheard.png`
@@ -144,7 +144,7 @@ Feature: Final display for FTPA decision and reasons
     #  Partially Granted / Reheard Rule 32 (Final Decision: Granted - Scenario 8)
   Scenario: FTPA judge decision - Granted
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -168,7 +168,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 
@@ -215,7 +215,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_reheard.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_reheard.png`
@@ -250,7 +250,7 @@ Feature: Final display for FTPA decision and reasons
     #  Partially Granted / Remade Rule 32 (Final Decision: Granted - Scenario 8)
   Scenario: FTPA judge decision - Granted
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -274,7 +274,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
 
@@ -321,7 +321,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_reheard.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_allowed.png`
@@ -356,7 +356,7 @@ Feature: Final display for FTPA decision and reasons
     #  Reheard Rule 35 / Partially Granted (Final Decision: Granted - Scenario 8)
   Scenario: FTPA judge decision - Granted
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -383,7 +383,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 
@@ -438,7 +438,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_reheard.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_reheard.png`
@@ -473,7 +473,7 @@ Feature: Final display for FTPA decision and reasons
     #  Reheard Rule 32 / Partially Granted (Final Decision: Granted - Scenario 8)
   Scenario: FTPA judge decision - Granted
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -496,7 +496,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 
@@ -551,7 +551,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_reheard.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_reheard.png`
@@ -586,7 +586,7 @@ Feature: Final display for FTPA decision and reasons
     #  Remade Rule 32 / Partially Granted (Final Decision: Granted - Scenario 8)
   Scenario: FTPA judge decision - Granted
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -608,7 +608,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
 
@@ -663,7 +663,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_allowed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `ftpaGranted.png`
     And I should not see the image `appeal_allowed.png`

--- a/e2e/features/ftpa-display-final-decision-scenario-9.feature
+++ b/e2e/features/ftpa-display-final-decision-scenario-9.feature
@@ -1,22 +1,22 @@
 Feature: Final display for FTPA decision and reasons
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -33,7 +33,7 @@ Feature: Final display for FTPA decision and reasons
     #  Reheard Rule 35 / Refused (Final Decision: Reheard Rule 35 - Scenario 9)
   Scenario: FTPA judge decision - Reheard
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -60,7 +60,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 
@@ -110,7 +110,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `appeal_reheard.png`
     And I should not see the image `appeal_dismissed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
     And I should not see the image `appeal_dismissed.png`
@@ -145,7 +145,7 @@ Feature: Final display for FTPA decision and reasons
     #  Reheard Rule 32 / Refused (Final Decision: Reheard Rule 32 - Scenario 9)
   Scenario: FTPA judge decision - Reheard
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -168,7 +168,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 
@@ -218,7 +218,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `appeal_reheard.png`
     And I should not see the image `appeal_dismissed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
     And I should not see the image `appeal_dismissed.png`
@@ -275,7 +275,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 
@@ -299,7 +299,7 @@ Feature: Final display for FTPA decision and reasons
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -320,7 +320,7 @@ Feature: Final display for FTPA decision and reasons
     And I should see the image `appeal_reheard.png`
     And I should not see the image `appeal_dismissed.png`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
     And I should not see the image `appeal_dismissed.png`

--- a/e2e/features/ftpa-pre-hearing-to-decision.feature
+++ b/e2e/features/ftpa-pre-hearing-to-decision.feature
@@ -1,22 +1,22 @@
 Feature: TCW progresses case from pre-hearing to Decision - FTPA reheard decision (resident judge)
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -89,8 +89,8 @@ Feature: TCW progresses case from pre-hearing to Decision - FTPA reheard decisio
     And I click the `Continue` button
     And I click the `Send direction` button
 
-    When I switch to be a `Legal Rep`
-    And I submit hearing requirements with all no
+    When I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all no when in country
 
     When I switch to be a `Case Officer`
     Then I click the `review and submit` link
@@ -143,7 +143,7 @@ Feature: TCW progresses case from pre-hearing to Decision - FTPA reheard decisio
     And within the `Reheard decision and reason documents` collection's first item, I should see `-Gonzlez-decision-and-reasons-draft.docx` in the `Document` field
     And within the `Reheard decision and reason documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I should only see the `progress_legalRep_decision` case progress image
     And I should see the text `Do this next`
     And I should see the text `The judge is writing the decisions and reasons. You will be notified when it is available to view.`
@@ -293,7 +293,7 @@ Feature: TCW progresses case from pre-hearing to Decision - FTPA reheard decisio
     And I should see the text `These flags are only visible to the Tribunal`
     And I should see the image `caseFlagSetAsideReheard.svg`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I should only see the `progress_legalRep_decision` case progress image
     And I should see the text `Do this next`
     And I should see the text `The judge is writing the decisions and reasons. You will be notified when it is available to view.`

--- a/e2e/features/ftpa-reheard-appeal-hearing-requirements-not-submitted.feature
+++ b/e2e/features/ftpa-reheard-appeal-hearing-requirements-not-submitted.feature
@@ -1,22 +1,22 @@
 Feature: Hearing requirements not submitted - FTPA reheard decision (resident judge)
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -141,7 +141,7 @@ Feature: Hearing requirements not submitted - FTPA reheard decision (resident ju
     And I should see the `Record of requirements and requests` field
     And I should see the `Previous hearings` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I should only see the `progress_legalRep_listing` case progress image
     And I should see the text `What happens next`
     And I should see the text `You have not submitted any hearing requirements on behalf of the appellant.`

--- a/e2e/features/ftpa-reheard-appellant-apply-for-respondent-ftpa-overview-tab.feature
+++ b/e2e/features/ftpa-reheard-appellant-apply-for-respondent-ftpa-overview-tab.feature
@@ -1,22 +1,22 @@
 Feature: New Overview tab - FTPA resident judge records the appellant Reheard Decision (POU applies for respondent FTPA)
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -27,7 +27,7 @@ Feature: New Overview tab - FTPA resident judge records the appellant Reheard De
     And I start decision and reasons
     And I prepare decision and reasons
     And I send decision and reasons
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I apply for appellant FTPA
 
 
@@ -106,7 +106,7 @@ Feature: New Overview tab - FTPA resident judge records the appellant Reheard De
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
     And I should see the text `What happens next`
@@ -234,7 +234,7 @@ Feature: New Overview tab - FTPA resident judge records the appellant Reheard De
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
     And I should see the text `What happens next`

--- a/e2e/features/ftpa-reheard-decision-appellant-overview-tab.feature
+++ b/e2e/features/ftpa-reheard-decision-appellant-overview-tab.feature
@@ -1,22 +1,22 @@
 Feature: New Overview tab - FTPA resident judge records the appellant Reheard Decision
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -27,7 +27,7 @@ Feature: New Overview tab - FTPA resident judge records the appellant Reheard De
     And I start decision and reasons
     And I prepare decision and reasons
     And I send decision and reasons
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I apply for appellant FTPA
 
 
@@ -87,7 +87,7 @@ Feature: New Overview tab - FTPA resident judge records the appellant Reheard De
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
     And I should see the text `What happens next`

--- a/e2e/features/ftpa-reheard-respondent-apply-for-appellant-ftpa-overview-tab.feature
+++ b/e2e/features/ftpa-reheard-respondent-apply-for-appellant-ftpa-overview-tab.feature
@@ -1,22 +1,22 @@
 Feature: New Overview tab - FTPA resident judge records the respondent Reheard Decision (POU applies for appellant FTPA)
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -53,7 +53,7 @@ Feature: New Overview tab - FTPA resident judge records the respondent Reheard D
     And I click the `Close and Return to case details` button
     And I should see an alert confirming the case `has been updated with event: Resident judge FTPA decision`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     And I click the `Overview` tab
@@ -182,7 +182,7 @@ Feature: New Overview tab - FTPA resident judge records the respondent Reheard D
     And I click the `Close and Return to case details` button
     And I should see an alert confirming the case `has been updated with event: Resident judge FTPA decision`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I apply for appellant FTPA
 
     And I click the `Overview` tab

--- a/e2e/features/ftpa-respondent-leadership-judge-decision-and-reasons.feature
+++ b/e2e/features/ftpa-respondent-leadership-judge-decision-and-reasons.feature
@@ -1,22 +1,22 @@
 Feature: Leadership judge record the respondent decision and reasons
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -242,7 +242,7 @@ Feature: Leadership judge record the respondent decision and reasons
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `FTPA` tab
     And I should see the `FTPA` page
     And I should see the text `Home Office: Decision on permission to appeal`
@@ -276,7 +276,7 @@ Feature: Leadership judge record the respondent decision and reasons
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -555,7 +555,7 @@ Feature: Leadership judge record the respondent decision and reasons
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `FTPA` tab
     And I should see the `FTPA` page
     And I should see the text `Home Office: Decision on permission to appeal`
@@ -589,7 +589,7 @@ Feature: Leadership judge record the respondent decision and reasons
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -863,7 +863,7 @@ Feature: Leadership judge record the respondent decision and reasons
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `FTPA` tab
     And I should see the `FTPA` page
     And I should not see the text `Home Office: Decision on permission to appeal`
@@ -884,7 +884,7 @@ Feature: Leadership judge record the respondent decision and reasons
     And I should not see the `The outcome of the application` field
     And I should not see the `FTPA Decision and Reasons document` field
 
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -1145,7 +1145,7 @@ Feature: Leadership judge record the respondent decision and reasons
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `FTPA` tab
     And I should see the `FTPA` page
     And I should not see the text `Home Office: Decision on permission to appeal`

--- a/e2e/features/ftpa-respondent-resident-judge-decision-and-reasons.feature
+++ b/e2e/features/ftpa-respondent-resident-judge-decision-and-reasons.feature
@@ -1,22 +1,22 @@
 Feature: Resident judge record the appellant decision and reasons
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -132,7 +132,7 @@ Feature: Resident judge record the appellant decision and reasons
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `FTPA` tab
     And I should see the `FTPA` page
     And I should see `Permission granted` for the `The outcome of the application` field
@@ -205,7 +205,7 @@ Feature: Resident judge record the appellant decision and reasons
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `FTPA` tab
     And I should see the `FTPA` page
     And I should see `Permission granted` for the `The outcome of the application` field
@@ -221,7 +221,7 @@ Feature: Resident judge record the appellant decision and reasons
     And within the `FTPA Respondent Decision and Reasons documents` collection's first item, I should see `This is the ftpa decision and reasons` in the `Description` field
     And within the `FTPA Respondent Decision and Reasons documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
 
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -390,7 +390,7 @@ Feature: Resident judge record the appellant decision and reasons
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `FTPA` tab
     And I should see the `FTPA` page
     And I should see `Permission partially granted` for the `The outcome of the application` field
@@ -463,7 +463,7 @@ Feature: Resident judge record the appellant decision and reasons
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `FTPA` tab
     And I should see the `FTPA` page
     And I should see `Permission partially granted` for the `The outcome of the application` field
@@ -479,7 +479,7 @@ Feature: Resident judge record the appellant decision and reasons
     And within the `FTPA Respondent Decision and Reasons documents` collection's first item, I should see `This is the ftpa decision and reasons` in the `Description` field
     And within the `FTPA Respondent Decision and Reasons documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
 
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -689,13 +689,13 @@ Feature: Resident judge record the appellant decision and reasons
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I should see the image `appeal_dismissed.png`
     And I should see the text `The appeal has been dismissed. You have the right to apply for permission to appeal to the Upper Tribunal. You have 14 days to apply from the date the Decision and Reasons document was uploaded.`
     And I should not see the `The outcome of the application` field
     And I should not see the `FTPA Decision and Reasons document` field
 
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -876,7 +876,7 @@ Feature: Resident judge record the appellant decision and reasons
     And within the `FTPA Respondent Decision and Reasons documents` collection's first item, I should see `This is the ftpa decision and reasons` in the `Description` field
     And within the `FTPA Respondent Decision and Reasons documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `FTPA` tab
     And I should see the `FTPA` page
     And I should see `Decision set aside and to be reheard in the First-tier under rule 35` for the `The outcome of the application` field
@@ -900,7 +900,7 @@ Feature: Resident judge record the appellant decision and reasons
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -1063,7 +1063,7 @@ Feature: Resident judge record the appellant decision and reasons
     And within the `FTPA Respondent Decision and Reasons documents` collection's first item, I should see `This is the ftpa decision and reasons` in the `Description` field
     And within the `FTPA Respondent Decision and Reasons documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `FTPA` tab
     And I should see the `FTPA` page
     And I should see `Decision set aside and to be reheard in the First-tier under rule 32` for the `The outcome of the application` field
@@ -1085,7 +1085,7 @@ Feature: Resident judge record the appellant decision and reasons
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I apply for appellant FTPA
 
     When I switch to be a Judge
@@ -1291,7 +1291,7 @@ Feature: Resident judge record the appellant decision and reasons
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I apply for appellant FTPA
 
     When I switch to be a Judge

--- a/e2e/features/ftpa-respondent.feature
+++ b/e2e/features/ftpa-respondent.feature
@@ -2,22 +2,22 @@ Feature: FTPA Respondent application to the Upper Tribunal
 
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -146,8 +146,8 @@ Feature: FTPA Respondent application to the Upper Tribunal
     And within the `FTPA Home Office documents` collection's second item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
 
 
-    ## Legal Representative
-    When I switch to be a `Legal Rep`
+    ## Legal representative
+    When I switch to be a `Legal Org User Rep A`
 #    And I click the `Overview` tab
     And I should see the image `appeal_allowed.png`
     And I should see the text `What happens next`

--- a/e2e/features/ftpa-two-reheard-decisions-overview-tab.feature
+++ b/e2e/features/ftpa-two-reheard-decisions-overview-tab.feature
@@ -1,22 +1,22 @@
 Feature: New Overview tab - FTPA resident judge records the appellant 2 x Reheard Decisions
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -27,7 +27,7 @@ Feature: New Overview tab - FTPA resident judge records the appellant 2 x Rehear
     And I start decision and reasons
     And I prepare decision and reasons
     And I send decision and reasons
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I apply for appellant FTPA
 
 
@@ -119,7 +119,7 @@ Feature: New Overview tab - FTPA resident judge records the appellant 2 x Rehear
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
     And I should see the text `What happens next`
@@ -269,7 +269,7 @@ Feature: New Overview tab - FTPA resident judge records the appellant 2 x Rehear
     And within the `FTPA Decision and Reasons document` collection's first item, I should see `This is the ftpa decision and reasons` in the `Describe the document` field
     And I should see `{$TODAY|D MMM YYYY}` in the `Decision date` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I click the `Overview` tab
     And I should see the image `appeal_reheard.png`
     And I should see the text `What happens next`

--- a/e2e/features/generate-hearing-bundle.feature
+++ b/e2e/features/generate-hearing-bundle.feature
@@ -2,14 +2,14 @@ Feature: Generate hearing bundle
 
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I upload additional evidence
@@ -17,8 +17,8 @@ Feature: Generate hearing bundle
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`

--- a/e2e/features/home-office-all-overview-tabs.feature
+++ b/e2e/features/home-office-all-overview-tabs.feature
@@ -1,22 +1,22 @@
 Feature: Home Office all overview tabs from listing to decision state
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
 

--- a/e2e/features/home-office-exposure.feature
+++ b/e2e/features/home-office-exposure.feature
@@ -2,7 +2,7 @@ Feature: Different Home Office roles have different functionality
 
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
@@ -233,7 +233,7 @@ Feature: Different Home Office roles have different functionality
     And I should see the text `The Home Office will be notified when the Appeal Skeleton Argument is ready to review`
 
     # LR:
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
 
@@ -289,8 +289,8 @@ Feature: Different Home Office roles have different functionality
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
 

--- a/e2e/features/home-office-users-view-all-tabs.feature
+++ b/e2e/features/home-office-users-view-all-tabs.feature
@@ -1,7 +1,7 @@
 Feature: All home office users overview appeal case-details documents directions tabs view
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
@@ -9,15 +9,15 @@ Feature: All home office users overview appeal case-details documents directions
     And I request respondent evidence
     And I switch to be a `Case Officer`
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`

--- a/e2e/features/list-case-after-agreed-hearing-requirements.feature
+++ b/e2e/features/list-case-after-agreed-hearing-requirements.feature
@@ -2,22 +2,22 @@ Feature: List case and edit case listing after agreed hearing requirements stage
 
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
 

--- a/e2e/features/list-case.feature
+++ b/e2e/features/list-case.feature
@@ -3,22 +3,22 @@ Feature: List case
   @regression @list-case @RIA-412 @RIA-1571 @postcode @RIA-1380 @RIA-1976
   Scenario Outline: Listing the case produces a hearing notice (default for <hearingCentre> hearing centre)
 
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal with <address> address and <postcode> postcode
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -85,22 +85,22 @@ Feature: List case
   @regression @list-case @RIA-412 @RIA-1571 @RIA-1380
   Scenario: Listing the case produces a hearing notice
 
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`

--- a/e2e/features/make-an-application.feature
+++ b/e2e/features/make-an-application.feature
@@ -1,7 +1,7 @@
 Feature: Legal representative make an application
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
@@ -166,7 +166,7 @@ Feature: Legal representative make an application
     And I should see the option `Judge's review of application decision` for the `Type of application` field
     And I should see the option `Other` for the `Type of application` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     When I click the `Applications` tab
     Then I select the `Make an application` Next step
     And I should see the `Make an application` page
@@ -305,7 +305,7 @@ Feature: Legal representative make an application
     And within the `Application` collection's second item, I should see `{$TODAY|D MMM YYYY}` for the `Date application was made` field
     And within the `Application` collection's second item, I should see `Pending` in the `Decision` field
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     When I click the `Applications` tab
     And I should see the `Application` field
     And within the `Application` collection's first item, I should see `Respondent` in the `Applicant` field
@@ -330,7 +330,7 @@ Feature: Legal representative make an application
     And I should see the text `What happens next`
     And I should see the text `No further action required, unless either party asks for the decision to be reviewed by a judge.`
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     When I click the `Applications` tab
     Then I select the `Make an application` Next step
     And I should see the `Make an application` page
@@ -402,19 +402,19 @@ Feature: Legal representative make an application
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I click the `Applications` tab
     And I select the `Make an application` Next step
     And I should see the `Make an application` page
@@ -462,21 +462,21 @@ Feature: Legal representative make an application
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
     And I list the case
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     Then I click the `Applications` tab
     And I select the `Make an application` Next step
     And I should see the `Make an application` page

--- a/e2e/features/mark-appeal-as-paid-after-listing.feature
+++ b/e2e/features/mark-appeal-as-paid-after-listing.feature
@@ -1,21 +1,21 @@
 Feature: Mark appeal as paid after listing
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial PA appeal type with no remission and with hearing fee and pay offline
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`

--- a/e2e/features/noc-remove-representation-after-listing-tcw.feature
+++ b/e2e/features/noc-remove-representation-after-listing-tcw.feature
@@ -23,7 +23,7 @@ Feature: Notice of Change (common component) - Remove Representation by TCW and 
     And I add the appeal response
     And I request hearing requirements
     And I switch to be a `Legal Org User Rep A`
-    And I submit hearing requirements with all no
+    And I submit hearing requirements with all no when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements no path
     And I switch to be a `Admin Officer`
@@ -65,7 +65,7 @@ Feature: Notice of Change (common component) - Remove Representation by TCW and 
     And I add the appeal response
     And I request hearing requirements
     And I switch to be a `Legal Org User Rep A`
-    And I submit hearing requirements with all no
+    And I submit hearing requirements with all no when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements no path
     And I switch to be a `Admin Officer`

--- a/e2e/features/noc-remove-representation-after-listing.feature
+++ b/e2e/features/noc-remove-representation-after-listing.feature
@@ -23,7 +23,7 @@ Feature: Notice of Change (common component) - Remove Representation (after list
     And I add the appeal response
     And I request hearing requirements
     And I switch to be a `Legal Org User Rep A`
-    And I submit hearing requirements with all no
+    And I submit hearing requirements with all no when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements no path
     And I switch to be a `Admin Officer`

--- a/e2e/features/prepare-decisions-and-reasons.feature
+++ b/e2e/features/prepare-decisions-and-reasons.feature
@@ -2,22 +2,22 @@ Feature: Prepare decision and reasons
 
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`

--- a/e2e/features/record-grant-update-hearing-requirements.feature
+++ b/e2e/features/record-grant-update-hearing-requirements.feature
@@ -2,22 +2,22 @@ Feature: Record grant update hearing requirements
 
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
 

--- a/e2e/features/record-hearing-attendees-and-duration.feature
+++ b/e2e/features/record-hearing-attendees-and-duration.feature
@@ -1,22 +1,22 @@
 Feature: Record hearing attendees and duration
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`

--- a/e2e/features/redcord-allocated-judge.feature
+++ b/e2e/features/redcord-allocated-judge.feature
@@ -1,22 +1,22 @@
 Feature: Record allocated Judge
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -27,7 +27,7 @@ Feature: Record allocated Judge
     And I start decision and reasons
     And I prepare decision and reasons
     And I send decision and reasons
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I submit FTPA Appellant appeal
     And I switch to be a `Admin Officer`
 

--- a/e2e/features/relist-an-adjourned-case.feature
+++ b/e2e/features/relist-an-adjourned-case.feature
@@ -1,22 +1,22 @@
 Feature: Relist an adjourned hearing without a date case
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`

--- a/e2e/features/remote-hearing-case-list.feature
+++ b/e2e/features/remote-hearing-case-list.feature
@@ -20,7 +20,7 @@ Feature: Remote hearing during Submit hearing requirements
   Scenario: Record agreed hearing requirements with 'Yes' option selected for Remote hearing
 
     And I switch to be a `Legal Org User Rep A`
-    And I submit hearing requirements with all yes
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`

--- a/e2e/features/remote-hearing-edit-listing.feature
+++ b/e2e/features/remote-hearing-edit-listing.feature
@@ -44,7 +44,7 @@ Feature: Remote Hearing / Hearing Centre location transfers during edit listing
   Scenario: List the case with a Hearing Centre (Taylor House) location and re-list as a Remote Hearing
 
     And I switch to be a `Legal Org User Rep A`
-    And I submit hearing requirements with all no
+    And I submit hearing requirements with all no when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements no path
     And I switch to be a `Admin Officer`
@@ -61,7 +61,7 @@ Feature: Remote Hearing / Hearing Centre location transfers during edit listing
   Scenario: List the case as a Remote Hearing and re-list to a Hearing Centre (Taylor House) location
 
     And I switch to be a `Legal Org User Rep A`
-    And I submit hearing requirements with all no
+    And I submit hearing requirements with all no when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements no path
     And I switch to be a `Admin Officer`
@@ -78,7 +78,7 @@ Feature: Remote Hearing / Hearing Centre location transfers during edit listing
   Scenario: List the case as a Remote Hearing and re-list as a Remote Hearing
 
     And I switch to be a `Legal Org User Rep A`
-    And I submit hearing requirements with all no
+    And I submit hearing requirements with all no when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements no path
     And I switch to be a `Admin Officer`
@@ -97,7 +97,7 @@ Feature: Remote Hearing / Hearing Centre location transfers during edit listing
   Scenario: List the case as a Remote Hearing and re-list as a Remote Hearing with no changes
 
     And I switch to be a `Legal Org User Rep A`
-    And I submit hearing requirements with all no
+    And I submit hearing requirements with all no when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements no path
     And I switch to be a `Admin Officer`

--- a/e2e/features/remote-hearing-update-hearing-requirements.feature
+++ b/e2e/features/remote-hearing-update-hearing-requirements.feature
@@ -20,7 +20,7 @@ Feature: Remote hearing - TCW and Judge update hearing requirements & update hea
   Scenario: Remote hearing - TCW updates (all no) hearing requirements and hearing adjustments (with all yes)
 
     And I switch to be a `Legal Org User Rep A`
-    And I submit hearing requirements with all no
+    And I submit hearing requirements with all no when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements no path
     And I switch to be a `Admin Officer`
@@ -103,7 +103,7 @@ Feature: Remote hearing - TCW and Judge update hearing requirements & update hea
   Scenario: Remote hearing - TCW updates (all yes) hearing requirements and hearing adjustments (with all no)
 
     And I switch to be a `Legal Org User Rep A`
-    And I submit hearing requirements with all yes
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -173,7 +173,7 @@ Feature: Remote hearing - TCW and Judge update hearing requirements & update hea
   Scenario: Remote hearing - Judge updates (all no) hearing requirements and hearing adjustments (with all yes)
 
     And I switch to be a `Legal Org User Rep A`
-    And I submit hearing requirements with all no
+    And I submit hearing requirements with all no when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements no path
     And I switch to be a `Admin Officer`
@@ -255,7 +255,7 @@ Feature: Remote hearing - TCW and Judge update hearing requirements & update hea
   Scenario: Remote hearing - Judge updates (all yes) hearing requirements and hearing adjustments (with all no)
 
     And I switch to be a `Legal Org User Rep A`
-    And I submit hearing requirements with all yes
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`

--- a/e2e/features/remote-hearing.feature
+++ b/e2e/features/remote-hearing.feature
@@ -1,14 +1,14 @@
 Feature: Remote hearing during Submit hearing requirements
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my out of country now appeal with decision type `refusalOfHumanRights`
     And I submit my nonpayment appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
@@ -19,8 +19,8 @@ Feature: Remote hearing during Submit hearing requirements
   @RIA-3718 @remote-hearing @remote-hearing-yes
   Scenario: Submit hearing requirements with 'Yes' option selected for Remote hearing
 
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
 
     When I click the `Documents` tab
     Then I should see the `Documents` page
@@ -61,8 +61,8 @@ Feature: Remote hearing during Submit hearing requirements
   @RIA-3718 @remote-hearing @remote-hearing-no
   Scenario: Submit hearing requirements with 'No' option selected for Remote hearing
 
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all no
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all no when in country
 
     When I click the `Documents` tab
     Then I should see the `Documents` page
@@ -101,8 +101,8 @@ Feature: Remote hearing during Submit hearing requirements
   @RIA-3719 @remote-hearing @record-agreed-hearing-remote-hearing-no
   Scenario: Record agreed hearing requirements with 'No' option selected for Remote hearing
 
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all no
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all no when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements no path
 
@@ -116,7 +116,7 @@ Feature: Remote hearing during Submit hearing requirements
     Then I should not see the requests for additional adjustments no path
     Then I should see the agreed additional adjustments no path
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Hearing and appointment` tab
     Then I should not see the requests for additional adjustments no path
     Then I should see the agreed additional adjustments no path
@@ -129,8 +129,8 @@ Feature: Remote hearing during Submit hearing requirements
   @RIA-3719 @remote-hearing @record-agreed-hearing-remote-hearing-yes
   Scenario: Record agreed hearing requirements with 'Yes' option selected for Remote hearing
 
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
 
@@ -144,7 +144,7 @@ Feature: Remote hearing during Submit hearing requirements
     Then I should not see the requests for additional adjustments yes path
     And I should see the agreed additional adjustments yes path
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Hearing and appointment` tab
     Then I should not see the requests for additional adjustments yes path
     Then I should see the agreed additional adjustments yes path

--- a/e2e/features/send-case-preHearing-bundle-failed.feature
+++ b/e2e/features/send-case-preHearing-bundle-failed.feature
@@ -2,14 +2,14 @@ Feature: Send case to pre hearing state when unable to generate hearing bundle
 
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I upload additional evidence
@@ -17,8 +17,8 @@ Feature: Send case to pre hearing state when unable to generate hearing bundle
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -33,7 +33,7 @@ Feature: Send case to pre hearing state when unable to generate hearing bundle
     Then I should see an alert confirming the case `has been updated with event: Send to pre hearing`
     And I should only see the `caseOfficer_preHearing` case progress image
 
-    When I switch to be a `Legal Rep`
+    When I switch to be a `Legal Org User Rep A`
     And I click the `Overview` tab
     Then I should only see the `progress_legalRep_preHearing` case progress image
   

--- a/e2e/features/send-decision-and-reasons.feature
+++ b/e2e/features/send-decision-and-reasons.feature
@@ -2,22 +2,22 @@ Feature: Send decision and reasons
 
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`

--- a/e2e/features/start-decisions-and-reasons.feature
+++ b/e2e/features/start-decisions-and-reasons.feature
@@ -2,22 +2,22 @@ Feature: Start decision and reasons
 
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`

--- a/e2e/features/submit-hearing-requirements-giving-evidence-in-county-flow-extraction.feature
+++ b/e2e/features/submit-hearing-requirements-giving-evidence-in-county-flow-extraction.feature
@@ -21,6 +21,22 @@ Feature: Submit & update hearing requirements (summarised step flow) - Giving ev
 
     And I switch to be a `Legal Org User Rep A`
     And I submit hearing requirements with all no when in country
+    When I click the `Hearing and appointment` tab
+    Then I should see the `Requirements and requests` field
+    And I should see `No` in the `Will the appellant attend the hearing?` field
+    And I should see `No` in the `Will the appellant give oral evidence at the hearing?` field
+    And I should see `No` in the `Will any witnesses attend the hearing?` field
+    And I should see `No` in the `Will the appellant or anyone else be giving oral evidence from outside the United Kingdom?` field
+    And I should see `No` in the `Do you need interpreter services on the day?` field
+    And I should see `No` in the `Do you need a hearing room with step-free access?` field
+    And I should see `No` in the `Do you need a hearing loop?` field
+    And I should see `No` in the `Is there anything you'd like the Tribunal to consider when deciding if a video call is suitable?` field
+    And I should not see the agreed additional adjustments yes path
+    And I should see the text `Hearing requirements`
+    And I should see the text `Requests for additional adjustments`
+    And I should see the text `Record of requirements and requests`
+    And within the `Requirements and requests` collection's first item, I should see `-Gonzlez-hearing-requirements.PDF` in the `Document` field
+    And within the `Requirements and requests` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
 
     # Review hearing requirements (placeholder)
     # This flow requires testing for the field display changes
@@ -49,8 +65,18 @@ Feature: Submit & update hearing requirements (summarised step flow) - Giving ev
     And I update hearing requirements with all no when in country
     When I click the `Hearing and appointment` tab
     Then I should see the `Requirements and requests` field
-    And within the `Requirements and requests` collection's first item, I should see `-Gonzlez-hearing-requirements.PDF` in the `Document` field
-    And within the `Requirements and requests` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
+    And I should see `No` in the `Will the appellant attend the hearing?` field
+    And I should see `No` in the `Will the appellant give oral evidence at the hearing?` field
+    And I should see `No` in the `Will any witnesses attend the hearing?` field
+    And I should see `No` in the `Will the appellant or anyone else be giving oral evidence from outside the United Kingdom?` field
+    And I should see `No` in the `Do you need interpreter services on the day?` field
+    And I should see `No` in the `Do you need a hearing room with step-free access?` field
+    And I should see `No` in the `Do you need a hearing loop?` field
+    And I should see `No` in the `Is there anything you'd like the Tribunal to consider when deciding if a video call is suitable?` field
+    And I should not see the agreed additional adjustments yes path
+    And I should see the text `Hearing requirements`
+    And I should see the text `Requests for additional adjustments`
+    And I should see the text `Record of requirements and requests`
     And within the `Requirements and requests` collection's second item, I should see `-Gonzlez-hearing-requirements.PDF` in the `Document` field
     And within the `Requirements and requests` collection's second item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
 
@@ -70,12 +96,28 @@ Feature: Submit & update hearing requirements (summarised step flow) - Giving ev
     And I click the `Update` button
     And I click the `Close and Return to case details` button
 
-
   @RIA-3825 @RIA-3825-in-country-yes-flow @in-country-submit-hearing-requirements-giving-evidence-yes-path
   Scenario: Submit & update hearing requirements (summarised step flow) - Giving evidence from outside the UK (in country appeal) - Yes path
 
     And I switch to be a `Legal Org User Rep A`
     And I submit hearing requirements with all yes when in country
+
+    When I click the `Hearing and appointment` tab
+    Then I should see the `Requirements and requests` field
+    And I should see `Yes` in the `Will the appellant attend the hearing?` field
+    And I should see `Yes` in the `Will the appellant give oral evidence at the hearing?` field
+    And I should see `Yes` in the `Will any witnesses attend the hearing?` field
+    And I should see `Yes` in the `Will the appellant or anyone else be giving oral evidence from outside the United Kingdom?` field
+    And I should see `Yes` in the `Do you need interpreter services on the day?` field
+    And I should see `Yes` in the `Do you need a hearing room with step-free access?` field
+    And I should see `Yes` in the `Do you need a hearing loop?` field
+    And I should see `Yes` in the `Is there anything you'd like the Tribunal to consider when deciding if a video call is suitable?` field
+    And I should not see the agreed additional adjustments no path
+    And I should see the text `Hearing requirements`
+    And I should see the text `Requests for additional adjustments`
+    And I should see the text `Record of requirements and requests`
+    And within the `Requirements and requests` collection's first item, I should see `-Gonzlez-hearing-requirements.PDF` in the `Document` field
+    And within the `Requirements and requests` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
 
     # Review hearing requirements (placeholder)
     # This flow requires testing for the field display changes
@@ -109,6 +151,18 @@ Feature: Submit & update hearing requirements (summarised step flow) - Giving ev
     And I update hearing requirements with all yes when in country
     When I click the `Hearing and appointment` tab
     Then I should see the `Requirements and requests` field
+    And I should see `Yes` in the `Will the appellant attend the hearing?` field
+    And I should see `Yes` in the `Will the appellant give oral evidence at the hearing?` field
+    And I should see `Yes` in the `Will any witnesses attend the hearing?` field
+    And I should see `Yes` in the `Will the appellant or anyone else be giving oral evidence from outside the United Kingdom?` field
+    And I should see `Yes` in the `Do you need interpreter services on the day?` field
+    And I should see `Yes` in the `Do you need a hearing room with step-free access?` field
+    And I should see `Yes` in the `Do you need a hearing loop?` field
+    And I should see `Yes` in the `Is there anything you'd like the Tribunal to consider when deciding if a video call is suitable?` field
+    And I should not see the agreed additional adjustments no path
+    And I should see the text `Hearing requirements`
+    And I should see the text `Requests for additional adjustments`
+    And I should see the text `Record of requirements and requests`
     And within the `Requirements and requests` collection's first item, I should see `-Gonzlez-hearing-requirements.PDF` in the `Document` field
     And within the `Requirements and requests` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
     And within the `Requirements and requests` collection's second item, I should see `-Gonzlez-hearing-requirements.PDF` in the `Document` field

--- a/e2e/features/submit-hearing-requirements-giving-evidence-out-of-county-flow-extraction.feature
+++ b/e2e/features/submit-hearing-requirements-giving-evidence-out-of-county-flow-extraction.feature
@@ -21,6 +21,20 @@ Feature: Submit & update hearing requirements (summarised step flow) - Giving ev
 
     And I switch to be a `Legal Org User Rep A`
     And I submit hearing requirements with all no when out of country
+    When I click the `Hearing and appointment` tab
+    Then I should see the `Requirements and requests` field
+    And I should see `No` in the `Will the appellant or anyone else be giving oral evidence from outside the United Kingdom?` field
+    And I should not see the `Will the appellant attend the hearing?` field
+    And I should not see the `Will the appellant give oral evidence at the hearing?` field
+    And I should see `No` in the `Will any witnesses attend the hearing?` field
+    And I should see `No` in the `Do you need interpreter services on the day?` field
+    And I should see `No` in the `Do you need a hearing room with step-free access?` field
+    And I should see `No` in the `Do you need a hearing loop?` field
+    And I should see `No` in the `Is there anything you'd like the Tribunal to consider when deciding if a video call is suitable?` field
+    And I should not see the agreed additional adjustments yes path
+    And I should see the text `Hearing requirements`
+    And I should see the text `Requests for additional adjustments`
+    And I should see the text `Record of requirements and requests`
 
     # Review hearing requirements (placeholder)
     # This flow requires testing for the field display changes
@@ -49,6 +63,18 @@ Feature: Submit & update hearing requirements (summarised step flow) - Giving ev
     And I update hearing requirements with all no when out of country
     When I click the `Hearing and appointment` tab
     Then I should see the `Requirements and requests` field
+    And I should see `No` in the `Will the appellant or anyone else be giving oral evidence from outside the United Kingdom?` field
+    And I should not see the `Will the appellant attend the hearing?` field
+    And I should not see the `Will the appellant give oral evidence at the hearing?` field
+    And I should see `No` in the `Will any witnesses attend the hearing?` field
+    And I should see `No` in the `Do you need interpreter services on the day?` field
+    And I should see `No` in the `Do you need a hearing room with step-free access?` field
+    And I should see `No` in the `Do you need a hearing loop?` field
+    And I should see `No` in the `Is there anything you'd like the Tribunal to consider when deciding if a video call is suitable?` field
+    And I should not see the agreed additional adjustments yes path
+    And I should see the text `Hearing requirements`
+    And I should see the text `Requests for additional adjustments`
+    And I should see the text `Record of requirements and requests`
     And within the `Requirements and requests` collection's first item, I should see `-Gonzlez-hearing-requirements.PDF` in the `Document` field
     And within the `Requirements and requests` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
     And within the `Requirements and requests` collection's second item, I should see `-Gonzlez-hearing-requirements.PDF` in the `Document` field
@@ -70,12 +96,27 @@ Feature: Submit & update hearing requirements (summarised step flow) - Giving ev
     And I click the `Update` button
     And I click the `Close and Return to case details` button
 
-
   @RIA-3825 @RIA-3825-out-of-country-yes-flow @out-of-country-submit-hearing-requirements-giving-evidence-yes-path
   Scenario: Submit & update hearing requirements (summarised step flow) - Giving evidence from outside the UK (out of country appeal) - Yes path
 
     And I switch to be a `Legal Org User Rep A`
     And I submit hearing requirements with all yes when out of country
+    When I click the `Hearing and appointment` tab
+    Then I should see the `Requirements and requests` field
+    And I should see `Yes` in the `Will the appellant or anyone else be giving oral evidence from outside the United Kingdom?` field
+    And I should not see the `Will the appellant attend the hearing?` field
+    And I should not see the `Will the appellant give oral evidence at the hearing?` field
+    And I should see `Yes` in the `Will any witnesses attend the hearing?` field
+    And I should see `Yes` in the `Do you need interpreter services on the day?` field
+    And I should see `Yes` in the `Do you need a hearing room with step-free access?` field
+    And I should see `Yes` in the `Do you need a hearing loop?` field
+    And I should see `Yes` in the `Is there anything you'd like the Tribunal to consider when deciding if a video call is suitable?` field
+    And I should not see the agreed additional adjustments no path
+    And I should see the text `Hearing requirements`
+    And I should see the text `Requests for additional adjustments`
+    And I should see the text `Record of requirements and requests`
+    And within the `Requirements and requests` collection's first item, I should see `-Gonzlez-hearing-requirements.PDF` in the `Document` field
+    And within the `Requirements and requests` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
 
     # Review hearing requirements (placeholder)
     # This flow requires testing for the field display changes
@@ -109,6 +150,20 @@ Feature: Submit & update hearing requirements (summarised step flow) - Giving ev
     And I update hearing requirements with all yes when out of country
     When I click the `Hearing and appointment` tab
     Then I should see the `Requirements and requests` field
+    And I should see `Yes` in the `Will the appellant or anyone else be giving oral evidence from outside the United Kingdom?` field
+    And I should not see the `Will the appellant attend the hearing?` field
+    And I should not see the `Will the appellant give oral evidence at the hearing?` field
+    And I should see `Yes` in the `Will any witnesses attend the hearing?` field
+    And I should see `Yes` in the `Do you need interpreter services on the day?` field
+    And I should see `Yes` in the `Do you need a hearing room with step-free access?` field
+    And I should see `Yes` in the `Do you need a hearing loop?` field
+    And I should see `Yes` in the `Is there anything you'd like the Tribunal to consider when deciding if a video call is suitable?` field
+    And I should not see the agreed additional adjustments no path
+    And I should see the text `Hearing requirements`
+    And I should see the text `Requests for additional adjustments`
+    And I should see the text `Record of requirements and requests`
+    And within the `Requirements and requests` collection's first item, I should see `-Gonzlez-hearing-requirements.PDF` in the `Document` field
+    And within the `Requirements and requests` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
     And within the `Requirements and requests` collection's first item, I should see `-Gonzlez-hearing-requirements.PDF` in the `Document` field
     And within the `Requirements and requests` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
     And within the `Requirements and requests` collection's second item, I should see `-Gonzlez-hearing-requirements.PDF` in the `Document` field

--- a/e2e/features/update-hearing-adjustments.feature
+++ b/e2e/features/update-hearing-adjustments.feature
@@ -2,22 +2,22 @@ Feature: Update hearing adjustments after updating hearing requirements
 
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`

--- a/e2e/features/update-hearing-requirements.feature
+++ b/e2e/features/update-hearing-requirements.feature
@@ -2,14 +2,14 @@ Feature: Update hearing requirements
 
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I upload additional evidence
@@ -17,12 +17,12 @@ Feature: Update hearing requirements
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
 
   @update-hearing-requirements-yes-to-no @RIA-2031 @RIA-3555
   Scenario: Update hearing requirements to No answers
 
-    And I submit hearing requirements with all yes
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`
@@ -121,7 +121,7 @@ Feature: Update hearing requirements
   @update-hearing-requirements-no-to-yes @RIA-2031 @RIA-3555
   Scenario: Update hearing requirements to Yes answers
 
-    And I submit hearing requirements with all no
+    And I submit hearing requirements with all no when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements no path
     And I switch to be a `Admin Officer`

--- a/e2e/features/upload-hearing-recording.feature
+++ b/e2e/features/upload-hearing-recording.feature
@@ -1,22 +1,22 @@
 Feature: Upload hearing recording
 
   Background:
-    Given I am signed in as a `Legal Rep`
+    Given I am signed in as a `Legal Org User Rep A`
     And I create a new case
     And I save my initial appeal
     And I submit my appeal
     And I switch to be a `Case Officer`
     And I request respondent evidence
     And I upload respondent evidence
-    And I switch to be a `Legal Rep`
+    And I switch to be a `Legal Org User Rep A`
     And I build my case
     And I submit my case
     And I switch to be a `Case Officer`
     And I request respondent review
     And I add the appeal response
     And I request hearing requirements
-    And I switch to be a `Legal Rep`
-    And I submit hearing requirements with all yes
+    And I switch to be a `Legal Org User Rep A`
+    And I submit hearing requirements with all yes when in country
     And I switch to be a `Case Officer`
     And I record agreed hearing requirements yes path
     And I switch to be a `Admin Officer`

--- a/e2e/flows/start-appeal.flow.ts
+++ b/e2e/flows/start-appeal.flow.ts
@@ -143,6 +143,7 @@ export class StartAppealFlow {
         await browser.sleep(5000);
         await this.ccdFormPage.runAccessbility();
         await this.ccdFormPage.setFieldValue('Nationality', 'Has a nationality');
+        await browser.sleep(2000);
         await this.ccdFormPage.addCollectionItem('Nationality');
         await this.ccdFormPage.setFieldValue('Nationality', 'Finland', 'select list', 'first', 'Nationality', 'first');
 

--- a/e2e/flows/submit-hearing-requirements.flow.ts
+++ b/e2e/flows/submit-hearing-requirements.flow.ts
@@ -271,6 +271,7 @@ export class SubmitHearingRequirementsFlow {
                 'Will any witnesses attend the hearing?',
                 'Yes'
             );
+            await browser.sleep(2000);
             await this.ccdFormPage.click('Add new');
             await this.ccdFormPage.setFieldValue(
                 'Name',
@@ -296,6 +297,7 @@ export class SubmitHearingRequirementsFlow {
                 'Will any witnesses attend the hearing?',
                 'Yes'
             );
+            await browser.sleep(2000);
             await this.ccdFormPage.click('Add new');
             await this.ccdFormPage.setFieldValue(
                 'Name',
@@ -308,6 +310,7 @@ export class SubmitHearingRequirementsFlow {
             'Do you need interpreter services on the day?',
             'Yes'
         );
+        await browser.sleep(2000);
         await this.ccdFormPage.click('Add new');
         await this.ccdFormPage.setFieldValue(
             'Language',
@@ -410,7 +413,7 @@ export class SubmitHearingRequirementsFlow {
             'Are there any dates that the appellant or their on-day representation cannot attend?',
             'Yes'
         );
-
+        await browser.sleep(2000);
         await this.ccdFormPage.click('Add new');
         await browser.sleep(500);
         await this.ccdFormPage.setFieldValue(


### PR DESCRIPTION
### JIRA link (if applicable) ###

[RIA-3825](https://tools.hmcts.net/jira/browse/RIA-3825)


### Change description ###

This is a bulk update for all e2e tests that use the current **"And I submit hearing requirements with all yes"** and **"And I submit hearing requirements with all no"** step flows. 

These tests are now suffixed with **"when in country"** in order to continue working. This also allows QA to amend the test to  out of country by changing the suffix to **"when out of country"**

The tests also use the updated organisation legal rep: **Legal Org User Rep A**

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
