### PR TITLE
RIA-4510: Label change from "Legal representative documents" to "Appellant documents" as a common label between LR and AIP appeals

### DIFF
--- a/e2e/features/appeal-submission-pdf.feature
+++ b/e2e/features/appeal-submission-pdf.feature
@@ -11,6 +11,6 @@ Feature: Appeal submission PDF
 
     When I click the `Documents` tab
 
-    And I should see the `Legal representative documents` field
-    And within the `Legal representative documents` collection's first item, I should see `-Gonzlez-appeal-form.PDF` in the `Document` field
-    And within the `Legal representative documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
+    And I should see the `Appellant documents` field
+    And within the `Appellant documents` collection's first item, I should see `-Gonzlez-appeal-form.PDF` in the `Document` field
+    And within the `Appellant documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field

--- a/e2e/features/build-case.feature
+++ b/e2e/features/build-case.feature
@@ -46,13 +46,13 @@ Feature: Build case
     And I click the `Documents` tab
 
 
-    And within the `Legal representative documents` collection's first item, I should see `CaseArgument.pdf` in the `Document` field
-    And within the `Legal representative documents` collection's first item, I should see `This is the case argument` in the `Description` field
-    And within the `Legal representative documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
+    And within the `Appellant documents` collection's first item, I should see `CaseArgument.pdf` in the `Document` field
+    And within the `Appellant documents` collection's first item, I should see `This is the case argument` in the `Description` field
+    And within the `Appellant documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
 
-    And within the `Legal representative documents` collection's second item, I should see `Evidence1.pdf` in the `Document` field
-    And within the `Legal representative documents` collection's second item, I should see `This is the evidence` in the `Description` field
-    And within the `Legal representative documents` collection's second item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
+    And within the `Appellant documents` collection's second item, I should see `Evidence1.pdf` in the `Document` field
+    And within the `Appellant documents` collection's second item, I should see `This is the evidence` in the `Description` field
+    And within the `Appellant documents` collection's second item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
 
 
   @RIA-2918 @RIA-3534
@@ -66,13 +66,13 @@ Feature: Build case
     When I click the `Close and Return to case details` button
     And I click the `Documents` tab
 
-    And within the `Legal representative documents` collection's first item, I should see `2020-González-appeal-skeleton-argument.PDF` in the `Document` field
-    And within the `Legal representative documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
+    And within the `Appellant documents` collection's first item, I should see `2020-González-appeal-skeleton-argument.PDF` in the `Document` field
+    And within the `Appellant documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
 
-    And within the `Legal representative documents` collection's second item, I should see `CaseArgument.pdf` in the `Document` field
-    And within the `Legal representative documents` collection's second item, I should see `This is the case argument` in the `Description` field
-    And within the `Legal representative documents` collection's second item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
+    And within the `Appellant documents` collection's second item, I should see `CaseArgument.pdf` in the `Document` field
+    And within the `Appellant documents` collection's second item, I should see `This is the case argument` in the `Description` field
+    And within the `Appellant documents` collection's second item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
 
-    And within the `Legal representative documents` collection's third item, I should see `Evidence1.pdf` in the `Document` field
-    And within the `Legal representative documents` collection's third item, I should see `This is the evidence` in the `Description` field
-    And within the `Legal representative documents` collection's third item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
+    And within the `Appellant documents` collection's third item, I should see `Evidence1.pdf` in the `Document` field
+    And within the `Appellant documents` collection's third item, I should see `This is the evidence` in the `Description` field
+    And within the `Appellant documents` collection's third item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field

--- a/e2e/features/case-progression-save-and-continue-false.feature
+++ b/e2e/features/case-progression-save-and-continue-false.feature
@@ -1761,18 +1761,18 @@ Feature: Case progression path when case and continue is disabled
     And within the `Hearing documents` collection's second item, I should see `This is the case summary` in the `Description` field
     And within the `Hearing documents` collection's third item, I should see `-Gonzlez-hearing-notice.PDF` in the `Document` field
     And within the `Hearing documents` collection's third item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
-    And within the `Legal representative documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
-    And I should see the `Legal representative documents` field
-    And within the `Legal representative documents` collection's first item, I should see `-González-appeal-skeleton-argument.PDF` in the `Document` field
-    And within the `Legal representative documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
-    And within the `Legal representative documents` collection's second item, I should see `CaseArgument.pdf` in the `Document` field
-    And within the `Legal representative documents` collection's second item, I should see `This is the case argument` in the `Description` field
-    And within the `Legal representative documents` collection's second item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
-    And within the `Legal representative documents` collection's third item, I should see `CaseArgumentEvidence.pdf` in the `Document` field
-    And within the `Legal representative documents` collection's third item, I should see `The is the case argument evidence` in the `Description` field
-    And within the `Legal representative documents` collection's third item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
-    And within the `Legal representative documents` collection's fourth item, I should see `-Gonzlez-appeal-form.PDF` in the `Document` field
-    And within the `Legal representative documents` collection's fourth item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
+    And within the `Appellant documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
+    And I should see the `Appellant documents` field
+    And within the `Appellant documents` collection's first item, I should see `-González-appeal-skeleton-argument.PDF` in the `Document` field
+    And within the `Appellant documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
+    And within the `Appellant documents` collection's second item, I should see `CaseArgument.pdf` in the `Document` field
+    And within the `Appellant documents` collection's second item, I should see `This is the case argument` in the `Description` field
+    And within the `Appellant documents` collection's second item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
+    And within the `Appellant documents` collection's third item, I should see `CaseArgumentEvidence.pdf` in the `Document` field
+    And within the `Appellant documents` collection's third item, I should see `The is the case argument evidence` in the `Description` field
+    And within the `Appellant documents` collection's third item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
+    And within the `Appellant documents` collection's fourth item, I should see `-Gonzlez-appeal-form.PDF` in the `Document` field
+    And within the `Appellant documents` collection's fourth item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
     And within the `Respondent documents` collection's first item, I should see `AppealResponseUpdated.pdf` in the `Document` field
     And within the `Respondent documents` collection's first item, I should see `This is the updated appeal response` in the `Description` field
     And within the `Respondent documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
@@ -1831,7 +1831,7 @@ Feature: Case progression path when case and continue is disabled
     When I click the `Documents` tab
 
     And I should see the `Hearing documents` field
-    And I should see the `Legal representative documents` field
+    And I should see the `Appellant documents` field
     And I should see the `Respondent documents` field
 
     When I click the `Directions` tab

--- a/e2e/features/case-progression-save-and-continue-true.feature
+++ b/e2e/features/case-progression-save-and-continue-true.feature
@@ -1799,18 +1799,18 @@ Feature: Case progression path when save and continue is enabled
     And within the `Hearing documents` collection's second item, I should see `This is the case summary` in the `Description` field
     And within the `Hearing documents` collection's third item, I should see `-Gonzlez-hearing-notice.PDF` in the `Document` field
     And within the `Hearing documents` collection's third item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
-    And within the `Legal representative documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
-    And I should see the `Legal representative documents` field
-    And within the `Legal representative documents` collection's first item, I should see `-González-appeal-skeleton-argument.PDF` in the `Document` field
-    And within the `Legal representative documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
-    And within the `Legal representative documents` collection's second item, I should see `CaseArgument.pdf` in the `Document` field
-    And within the `Legal representative documents` collection's second item, I should see `This is the case argument` in the `Description` field
-    And within the `Legal representative documents` collection's second item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
-    And within the `Legal representative documents` collection's third item, I should see `CaseArgumentEvidence.pdf` in the `Document` field
-    And within the `Legal representative documents` collection's third item, I should see `The is the case argument evidence` in the `Description` field
-    And within the `Legal representative documents` collection's third item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
-    And within the `Legal representative documents` collection's fourth item, I should see `-Gonzlez-appeal-form.PDF` in the `Document` field
-    And within the `Legal representative documents` collection's fourth item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
+    And within the `Appellant documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
+    And I should see the `Appellant documents` field
+    And within the `Appellant documents` collection's first item, I should see `-González-appeal-skeleton-argument.PDF` in the `Document` field
+    And within the `Appellant documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
+    And within the `Appellant documents` collection's second item, I should see `CaseArgument.pdf` in the `Document` field
+    And within the `Appellant documents` collection's second item, I should see `This is the case argument` in the `Description` field
+    And within the `Appellant documents` collection's second item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
+    And within the `Appellant documents` collection's third item, I should see `CaseArgumentEvidence.pdf` in the `Document` field
+    And within the `Appellant documents` collection's third item, I should see `The is the case argument evidence` in the `Description` field
+    And within the `Appellant documents` collection's third item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
+    And within the `Appellant documents` collection's fourth item, I should see `-Gonzlez-appeal-form.PDF` in the `Document` field
+    And within the `Appellant documents` collection's fourth item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
     And within the `Respondent documents` collection's first item, I should see `AppealResponseUpdated.pdf` in the `Document` field
     And within the `Respondent documents` collection's first item, I should see `This is the updated appeal response` in the `Description` field
     And within the `Respondent documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
@@ -1869,7 +1869,7 @@ Feature: Case progression path when save and continue is enabled
     When I click the `Documents` tab
 
     And I should see the `Hearing documents` field
-    And I should see the `Legal representative documents` field
+    And I should see the `Appellant documents` field
     And I should see the `Respondent documents` field
 
     When I click the `Directions` tab

--- a/e2e/features/edit-appeal.feature
+++ b/e2e/features/edit-appeal.feature
@@ -251,9 +251,9 @@ Feature: Edit appeal application
 
     When I click the `Documents` tab
 
-    And I should see the `Legal representative documents` field
-    And within the `Legal representative documents` collection's first item, I should see `-Smith-appeal-form.PDF` in the `Document` field
-    And within the `Legal representative documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
+    And I should see the `Appellant documents` field
+    And within the `Appellant documents` collection's first item, I should see `-Smith-appeal-form.PDF` in the `Document` field
+    And within the `Appellant documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
 
   @regression @edit-appeal-after-submit-out-of-time @RIA-1359
   Scenario: Edit submitted appeal when submitted out of time
@@ -390,9 +390,9 @@ Feature: Edit appeal application
 
     When I click the `Documents` tab
 
-    And I should see the `Legal representative documents` field
-    And within the `Legal representative documents` collection's first item, I should see `-Smith-appeal-form.PDF` in the `Document` field
-    And within the `Legal representative documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
+    And I should see the `Appellant documents` field
+    And within the `Appellant documents` collection's first item, I should see `-Smith-appeal-form.PDF` in the `Document` field
+    And within the `Appellant documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
 
     When I click the `Appeal` tab
     Then I should see the `Appeal details` page

--- a/e2e/features/generate-skeleton-bundle.feature
+++ b/e2e/features/generate-skeleton-bundle.feature
@@ -20,5 +20,5 @@ Feature: Generate skeleton bundle
     And I click the `Close and Return to case details` button
     And I click the `Documents` tab
 
-    And within the `Legal representative documents` collection's first item, I should see `-González-appeal-skeleton-argument.PDF` in the `Document` field
-    And within the `Legal representative documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
+    And within the `Appellant documents` collection's first item, I should see `-González-appeal-skeleton-argument.PDF` in the `Document` field
+    And within the `Appellant documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field

--- a/e2e/features/home-office-users-view-all-tabs.feature
+++ b/e2e/features/home-office-users-view-all-tabs.feature
@@ -60,17 +60,17 @@ Feature: All home office users overview appeal case-details documents directions
     And within the `Hearing documents` collection's second item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
     And within the `Hearing documents` collection's third item, I should see `-Gonzlez-hearing-notice.PDF` in the `Document` field
     And within the `Hearing documents` collection's second item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
-    And I should see the `Legal representative documents` field
-    And within the `Legal representative documents` collection's first item, I should see `-González-appeal-skeleton-argument.PDF` in the `Document` field
-    And within the `Legal representative documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
-    And within the `Legal representative documents` collection's second item, I should see `CaseArgument.pdf` in the `Document` field
-    And within the `Legal representative documents` collection's second item, I should see `This is the case argument` in the `Description` field
-    And within the `Legal representative documents` collection's second item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
-    And within the `Legal representative documents` collection's third item, I should see `CaseArgumentEvidence.pdf` in the `Document` field
-    And within the `Legal representative documents` collection's third item, I should see `The is the case argument evidence` in the `Description` field
-    And within the `Legal representative documents` collection's third item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
-    And within the `Legal representative documents` collection's fourth item, I should see `-Gonzlez-appeal-form.PDF` in the `Document` field
-    And within the `Legal representative documents` collection's fourth item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
+    And I should see the `Appellant documents` field
+    And within the `Appellant documents` collection's first item, I should see `-González-appeal-skeleton-argument.PDF` in the `Document` field
+    And within the `Appellant documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
+    And within the `Appellant documents` collection's second item, I should see `CaseArgument.pdf` in the `Document` field
+    And within the `Appellant documents` collection's second item, I should see `This is the case argument` in the `Description` field
+    And within the `Appellant documents` collection's second item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
+    And within the `Appellant documents` collection's third item, I should see `CaseArgumentEvidence.pdf` in the `Document` field
+    And within the `Appellant documents` collection's third item, I should see `The is the case argument evidence` in the `Description` field
+    And within the `Appellant documents` collection's third item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
+    And within the `Appellant documents` collection's fourth item, I should see `-Gonzlez-appeal-form.PDF` in the `Document` field
+    And within the `Appellant documents` collection's fourth item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
     And within the `Respondent documents` collection's first item, I should see `AppealResponse.pdf` in the `Document` field
     And within the `Respondent documents` collection's first item, I should see `This is the appeal response` in the `Description` field
     And within the `Respondent documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field

--- a/e2e/features/share-a-case.feature
+++ b/e2e/features/share-a-case.feature
@@ -23,7 +23,7 @@ Feature: Share a case
     And I should not see the decision fields
     And I click the `Documents` tab
 
-    And I should see the `Legal representative documents` field
-    And within the `Legal representative documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
+    And I should see the `Appellant documents` field
+    And within the `Appellant documents` collection's first item, I should see `{$TODAY|D MMM YYYY}` for the `Date uploaded` field
     And I click the `Directions` tab
     And I should see the `Directions` field

--- a/e2e/features/start-appeal-grounds-of-appeal-ooc.feature
+++ b/e2e/features/start-appeal-grounds-of-appeal-ooc.feature
@@ -92,7 +92,7 @@ Feature: Grounds of appeal
     And I should see the text `Removing the appellant from the UK would be unlawful under section 6 of the Human Rights Act 1998`
 
     When I click the `Documents` tab
-    Then within the `Legal representative documents` collection's first item, I should see `-Gonzlez-appeal-form.PDF` in the `Document` field
+    Then within the `Appellant documents` collection's first item, I should see `-Gonzlez-appeal-form.PDF` in the `Document` field
 
   @start-appeal-ooc @RIA-4253-EA @RIA-4253
   Scenario: Grounds of appeal are captured for EEA refusal type cases
@@ -117,7 +117,7 @@ Feature: Grounds of appeal
     And I should see the text `The decision breaches the appellant's rights under the EEA regulations`
 
     When I click the `Documents` tab
-    And within the `Legal representative documents` collection's first item, I should see `-Gonzlez-appeal-form.PDF` in the `Document` field
+    And within the `Appellant documents` collection's first item, I should see `-Gonzlez-appeal-form.PDF` in the `Document` field
 
   @start-appeal-ooc @RIA-4253-HU @RIA-4253
   Scenario: Grounds of appeal are captured for human rights refusal type cases
@@ -142,4 +142,4 @@ Feature: Grounds of appeal
     And I should see the text `The decision is unlawful under section 6 of the Human Rights Act 1998`
 
     When I click the `Documents` tab
-    And within the `Legal representative documents` collection's first item, I should see `-Gonzlez-appeal-form.PDF` in the `Document` field
+    And within the `Appellant documents` collection's first item, I should see `-Gonzlez-appeal-form.PDF` in the `Document` field

--- a/e2e/features/start-appeal-grounds-of-appeal.feature
+++ b/e2e/features/start-appeal-grounds-of-appeal.feature
@@ -116,7 +116,7 @@ Feature: Grounds of appeal
 
     When I click the `Documents` tab
 
-    And within the `Legal representative documents` collection's first item, I should see `-Gonzlez-appeal-form.PDF` in the `Document` field
+    And within the `Appellant documents` collection's first item, I should see `-Gonzlez-appeal-form.PDF` in the `Document` field
 
   @regression @start-appeal @RIA-2733-EA @RIA-2693
   Scenario: Grounds of appeal are captured for EEA refusal type cases
@@ -150,7 +150,7 @@ Feature: Grounds of appeal
 
     When I click the `Documents` tab
 
-    And within the `Legal representative documents` collection's first item, I should see `-Gonzlez-appeal-form.PDF` in the `Document` field
+    And within the `Appellant documents` collection's first item, I should see `-Gonzlez-appeal-form.PDF` in the `Document` field
 
   @regression @start-appeal @RIA-2733-HU @RIA-2693
   Scenario: Grounds of appeal are captured for human rights refusal type cases
@@ -184,4 +184,4 @@ Feature: Grounds of appeal
 
     When I click the `Documents` tab
 
-    And within the `Legal representative documents` collection's first item, I should see `-Gonzlez-appeal-form.PDF` in the `Document` field
+    And within the `Appellant documents` collection's first item, I should see `-Gonzlez-appeal-form.PDF` in the `Document` field


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-4510


### Change description ###
Label change from "Legal representative documents" to "Appellant documents" as a common label between LR and AIP appeals


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
