### PR TITLE
added a refresh page to start of log in for submit-appeal.feature to …

### DIFF
--- a/e2e/features/submit-appeal.feature
+++ b/e2e/features/submit-appeal.feature
@@ -4,7 +4,7 @@ Feature: Submit appeal application
     Given I am signed in as a `Legal Org User Rep A`
     Then I wait for 5 seconds
     And I refresh the page
-    Then I wait for 20 seconds
+    Then I wait for 30 seconds
     And I create a new case
     And I save my initial PA appeal type without remission and with hearing fee and pay now
     And I wait for 5 seconds


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###
Added "refresh page" at the start of submit-appeal feature in order to stop builds from getting stuck on blank screen after log in.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
